### PR TITLE
Bump all npm package dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,14 @@
 {
   "name": "nais-testapp",
-  "version": "56.0.0",
+  "version": "62.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -11,6 +16,14 @@
       "requires": {
         "mime-types": "2.1.18",
         "negotiator": "0.6.1"
+      }
+    },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "5.0.0"
       }
     },
     "ajv": {
@@ -24,10 +37,51 @@
         "json-schema-traverse": "0.3.1"
       }
     },
+    "ansi-escapes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "1.9.2"
+      }
+    },
+    "ansicolors": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.3",
@@ -39,6 +93,26 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "ast-types": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
+      "integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw=="
+    },
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "requires": {
+        "lodash": "4.17.10"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -49,10 +123,10 @@
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
-    "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -90,23 +164,116 @@
         "type-is": "1.6.16"
       }
     },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "hoek": "4.2.1"
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
       }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.5.0"
+      }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
+      }
+    },
+    "clone-deep": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.3.0.tgz",
+      "integrity": "sha1-NIxhrpzb4O3+BT2R/0zFIdeQ7eg=",
+      "requires": {
+        "for-own": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "kind-of": "3.2.2",
+        "shallow-clone": "0.1.2"
+      }
     },
     "cluster-key-slot": {
       "version": "1.0.8",
@@ -118,12 +285,48 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "color-convert": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "requires": {
+        "color-name": "1.1.1"
+      }
+    },
+    "color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+    },
     "combined-stream": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
         "delayed-stream": "1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "configstore": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "requires": {
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.3.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "content-disposition": {
@@ -146,28 +349,20 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "core-js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+      "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        }
-      }
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -177,12 +372,37 @@
         "assert-plus": "1.0.0"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
+      "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "degenerator": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
+      "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
+      "requires": {
+        "ast-types": "0.11.5",
+        "escodegen": "1.11.0",
+        "esprima": "3.1.3"
       }
     },
     "delayed-stream": {
@@ -205,6 +425,14 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "requires": {
+        "is-obj": "1.0.1"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -219,15 +447,65 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "email-validator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
+      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ=="
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "4.2.4"
+      }
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escodegen": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+      "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+      "requires": {
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
+      }
+    },
+    "esprima": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
@@ -276,31 +554,26 @@
       "resolved": "https://registry.npmjs.org/express-physical/-/express-physical-0.4.0.tgz",
       "integrity": "sha512-ocT/mIU5yC038RqNjTRrQJuCvTnAAvZNRRjDJuwT7A3CeVYM5r4HoOdeTaEPP3gf1tnoquU/eYmFGtMPN8VpeA==",
       "requires": {
-        "async": "2.6.0",
+        "async": "2.6.1",
         "ramda": "0.25.0",
         "snakecase-keys": "1.1.0",
         "spected": "0.6.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "ramda": {
-          "version": "0.25.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-          "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
-        }
       }
     },
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "requires": {
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.19",
+        "tmp": "0.0.33"
+      }
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -316,6 +589,24 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "finalhandler": {
       "version": "1.1.1",
@@ -335,6 +626,19 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/flexbuffer/-/flexbuffer-0.0.6.tgz",
       "integrity": "sha1-A5/fI/iCPkQMOPMnfm/vEXQhWzA="
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "requires": {
+        "for-in": "1.0.2"
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -361,6 +665,51 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-extra": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.2"
+      }
+    },
+    "ftp": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
+      "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
+      "requires": {
+        "readable-stream": "1.1.14",
+        "xregexp": "2.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        }
+      }
+    },
+    "get-uri": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.2.tgz",
+      "integrity": "sha512-ZD325dMZOgerGqF/rF6vZXyFGTAay62svjQIT+X/oU2PtxYpFxvSkbsdi+oxIrsNxlZVd4y8wUDqkaExWTI/Cw==",
+      "requires": {
+        "data-uri-to-buffer": "1.2.0",
+        "debug": "2.6.9",
+        "extend": "3.0.1",
+        "file-uri-to-path": "1.0.0",
+        "ftp": "0.3.10",
+        "readable-stream": "2.3.6"
+      }
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -369,35 +718,48 @@
         "assert-plus": "1.0.0"
       }
     },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "graphlib": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
+      "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
-    "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "hasbin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/hasbin/-/hasbin-1.2.3.tgz",
+      "integrity": "sha1-eMWSaJPIAhXCtWiuH9P8q3omlrA=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "async": "1.5.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        }
       }
     },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
-      }
-    },
-    "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
     },
     "http-errors": {
       "version": "1.6.3",
@@ -410,6 +772,25 @@
         "statuses": "1.4.0"
       }
     },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "requires": {
+        "agent-base": "4.2.1",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -420,15 +801,75 @@
         "sshpk": "1.14.1"
       }
     },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "4.2.1",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "requires": {
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.2.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.4",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ioredis": {
       "version": "3.2.2",
@@ -470,15 +911,79 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
       "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
     },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "js-yaml": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        }
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -501,6 +1006,14 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -512,6 +1025,86 @@
         "verror": "1.10.0"
       }
     },
+    "jszip": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+      "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+      "requires": {
+        "core-js": "2.3.0",
+        "es6-promise": "3.0.2",
+        "lie": "3.1.1",
+        "pako": "1.0.6",
+        "readable-stream": "2.0.6"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+          "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        }
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
+    },
+    "lazy-cache": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+      "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "requires": {
+        "immediate": "3.0.6"
+      }
+    },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
@@ -521,6 +1114,11 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
+    "lodash.assignin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
     },
     "lodash.bind": {
       "version": "4.2.1",
@@ -557,6 +1155,11 @@
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.isempty": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
@@ -587,6 +1190,11 @@
       "resolved": "https://registry.npmjs.org/lodash.sample/-/lodash.sample-4.2.1.tgz",
       "integrity": "sha1-XkKRsMdT+hq+sKq4+ynfG2bwf20="
     },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+    },
     "lodash.shuffle": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz",
@@ -596,6 +1204,28 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
       "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c="
+    },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "macos-release": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
+      "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
+    },
+    "make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "requires": {
+        "pify": "3.0.0"
+      }
     },
     "map-obj": {
       "version": "2.0.0",
@@ -635,36 +1265,102 @@
         "mime-db": "1.33.0"
       }
     },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+      "requires": {
+        "for-in": "0.1.8",
+        "is-extendable": "0.1.1"
+      },
+      "dependencies": {
+        "for-in": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+    },
+    "nconf": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
+      "integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+      "requires": {
+        "async": "1.5.2",
+        "ini": "1.3.5",
+        "secure-keys": "1.0.0",
+        "yargs": "3.32.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        }
+      }
+    },
+    "needle": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.2.tgz",
+      "integrity": "sha512-mW7W8dKuVYefCpNzE3Z7xUmPI9wSrSL/1qH31YGMxmSOAnjatS3S9Zv3cmiHrhx3Jkp1SrWWBdOFXjfF48Uq3A==",
+      "requires": {
+        "debug": "2.6.9",
+        "iconv-lite": "0.4.19",
+        "sax": "1.2.4"
+      }
     },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
+    "netmask": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
+    },
     "npm": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.0.0.tgz",
-      "integrity": "sha512-EtM7gNAgMdQeUh8SW2bsaogywVS37lPhf2GYAf2vxR1pktxxT02CW8BHrx59MSbG3ZrRBbcOhpe03gts+eAbdA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.4.0.tgz",
+      "integrity": "sha512-k0VteQaxRuI1mREBxCtLUksesD2ZmX5gxjXNEjTmTrxQ3SHW22InkCKyX4NzoeGAYtgmDg5MuE7rcXYod7xgug==",
       "requires": {
-        "JSONStream": "1.3.2",
+        "JSONStream": "1.3.3",
         "abbrev": "1.1.1",
-        "ansi-regex": "3.0.0",
         "ansicolors": "0.3.2",
         "ansistyles": "0.1.3",
         "aproba": "1.2.0",
         "archy": "1.0.0",
         "bin-links": "1.1.2",
         "bluebird": "3.5.1",
-        "byte-size": "4.0.2",
-        "cacache": "11.0.1",
+        "byte-size": "4.0.3",
+        "cacache": "11.1.0",
         "call-limit": "1.1.0",
         "chownr": "1.0.1",
         "cli-columns": "3.1.2",
-        "cli-table2": "0.2.0",
+        "cli-table3": "0.5.0",
         "cmd-shim": "2.0.2",
         "columnify": "1.5.4",
         "config-chain": "1.1.11",
@@ -673,7 +1369,7 @@
         "detect-newline": "2.1.0",
         "dezalgo": "1.0.3",
         "editor": "1.0.0",
-        "figgy-pudding": "3.1.0",
+        "figgy-pudding": "3.2.0",
         "find-npm-prefix": "1.0.2",
         "fs-vacuum": "1.2.10",
         "fs-write-stream-atomic": "1.0.10",
@@ -681,20 +1377,21 @@
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
         "has-unicode": "2.0.1",
-        "hosted-git-info": "2.6.0",
-        "iferr": "1.0.0",
+        "hosted-git-info": "2.7.1",
+        "iferr": "1.0.2",
         "imurmurhash": "0.1.4",
         "inflight": "1.0.6",
         "inherits": "2.0.3",
         "ini": "1.3.5",
         "init-package-json": "1.10.3",
-        "is-cidr": "2.0.5",
+        "is-cidr": "2.0.6",
         "json-parse-better-errors": "1.0.2",
         "lazy-property": "1.0.0",
-        "libcipm": "1.6.2",
+        "libcipm": "2.0.1",
         "libnpmhook": "4.0.1",
         "libnpx": "10.2.0",
-        "lockfile": "1.0.3",
+        "lock-verify": "2.0.2",
+        "lockfile": "1.0.4",
         "lodash._baseindexof": "3.1.0",
         "lodash._baseuniq": "4.6.0",
         "lodash._bindcallback": "3.0.1",
@@ -706,22 +1403,22 @@
         "lodash.union": "4.6.0",
         "lodash.uniq": "4.5.0",
         "lodash.without": "4.4.0",
-        "lru-cache": "4.1.2",
+        "lru-cache": "4.1.3",
         "meant": "1.0.1",
         "mississippi": "3.0.0",
         "mkdirp": "0.5.1",
         "move-concurrently": "1.0.1",
-        "node-gyp": "3.6.2",
+        "node-gyp": "3.8.0",
         "nopt": "4.0.1",
         "normalize-package-data": "2.4.0",
-        "npm-audit-report": "1.0.5",
+        "npm-audit-report": "1.3.1",
         "npm-cache-filename": "1.0.2",
         "npm-install-checks": "3.0.0",
-        "npm-lifecycle": "2.0.1",
+        "npm-lifecycle": "2.0.3",
         "npm-package-arg": "6.1.0",
         "npm-packlist": "1.1.10",
         "npm-pick-manifest": "2.1.0",
-        "npm-profile": "3.0.1",
+        "npm-profile": "3.0.2",
         "npm-registry-client": "8.5.1",
         "npm-registry-fetch": "1.1.0",
         "npm-user-validate": "1.0.0",
@@ -729,11 +1426,11 @@
         "once": "1.4.0",
         "opener": "1.4.3",
         "osenv": "0.1.5",
-        "pacote": "8.1.0",
+        "pacote": "8.1.6",
         "path-is-inside": "1.0.2",
         "promise-inflight": "1.0.1",
         "qrcode-terminal": "0.12.0",
-        "query-string": "6.0.0",
+        "query-string": "6.1.0",
         "qw": "1.0.1",
         "read": "1.0.7",
         "read-cmd-shim": "1.0.1",
@@ -742,59 +1439,86 @@
         "read-package-tree": "5.2.1",
         "readable-stream": "2.3.6",
         "readdir-scoped-modules": "1.0.2",
-        "request": "2.85.0",
+        "request": "2.87.0",
         "retry": "0.12.0",
         "rimraf": "2.6.2",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "semver": "5.5.0",
         "sha": "2.0.1",
         "slide": "1.1.6",
         "sorted-object": "2.0.1",
         "sorted-union-stream": "2.1.3",
         "ssri": "6.0.0",
-        "strip-ansi": "4.0.0",
-        "tar": "4.4.1",
+        "stringify-package": "1.0.0",
+        "tar": "4.4.6",
         "text-table": "0.2.0",
         "tiny-relative-date": "1.3.0",
         "uid-number": "0.0.6",
         "umask": "1.1.0",
         "unique-filename": "1.1.0",
         "unpipe": "1.0.0",
-        "update-notifier": "2.4.0",
-        "uuid": "3.2.1",
-        "validate-npm-package-license": "3.0.3",
+        "update-notifier": "2.5.0",
+        "uuid": "3.3.2",
+        "validate-npm-package-license": "3.0.4",
         "validate-npm-package-name": "3.0.0",
-        "which": "1.3.0",
+        "which": "1.3.1",
         "worker-farm": "1.6.0",
-        "wrappy": "1.0.2",
         "write-file-atomic": "2.3.0"
       },
       "dependencies": {
         "JSONStream": {
-          "version": "1.3.2",
+          "version": "1.3.3",
           "bundled": true,
           "requires": {
             "jsonparse": "1.3.1",
             "through": "2.3.8"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
-            }
           }
         },
         "abbrev": {
           "version": "1.1.1",
           "bundled": true
         },
+        "agent-base": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "es6-promisify": "5.0.0"
+          }
+        },
+        "agentkeepalive": {
+          "version": "3.4.1",
+          "bundled": true,
+          "requires": {
+            "humanize-ms": "1.2.1"
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "bundled": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "ansi-align": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "2.1.1"
+          }
+        },
         "ansi-regex": {
-          "version": "3.0.0",
+          "version": "2.1.1",
           "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
         },
         "ansicolors": {
           "version": "0.3.2",
@@ -812,6 +1536,50 @@
           "version": "1.0.0",
           "bundled": true
         },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.7.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
         "bin-links": {
           "version": "1.1.2",
           "bundled": true,
@@ -823,24 +1591,68 @@
             "write-file-atomic": "2.3.0"
           }
         },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
         "bluebird": {
           "version": "3.5.1",
           "bundled": true
         },
+        "boxen": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "ansi-align": "2.0.0",
+            "camelcase": "4.1.0",
+            "chalk": "2.4.1",
+            "cli-boxes": "1.0.0",
+            "string-width": "2.1.1",
+            "term-size": "1.2.0",
+            "widest-line": "2.0.0"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-from": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "builtins": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "byline": {
+          "version": "5.0.0",
+          "bundled": true
+        },
         "byte-size": {
-          "version": "4.0.2",
+          "version": "4.0.3",
           "bundled": true
         },
         "cacache": {
-          "version": "11.0.1",
+          "version": "11.1.0",
           "bundled": true,
           "requires": {
             "bluebird": "3.5.1",
             "chownr": "1.0.1",
-            "figgy-pudding": "3.1.0",
+            "figgy-pudding": "3.2.0",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
-            "lru-cache": "4.1.2",
+            "lru-cache": "4.1.3",
             "mississippi": "3.0.0",
             "mkdirp": "0.5.1",
             "move-concurrently": "1.0.1",
@@ -849,20 +1661,50 @@
             "ssri": "6.0.0",
             "unique-filename": "1.1.0",
             "y18n": "4.0.0"
-          },
-          "dependencies": {
-            "y18n": {
-              "version": "4.0.0",
-              "bundled": true
-            }
           }
         },
         "call-limit": {
           "version": "1.1.0",
           "bundled": true
         },
+        "camelcase": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "capture-stack-trace": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
         "chownr": {
           "version": "1.0.1",
+          "bundled": true
+        },
+        "ci-info": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "cidr-regex": {
+          "version": "2.0.9",
+          "bundled": true,
+          "requires": {
+            "ip-regex": "2.1.0"
+          }
+        },
+        "cli-boxes": {
+          "version": "1.0.0",
           "bundled": true
         },
         "cli-columns": {
@@ -871,104 +1713,42 @@
           "requires": {
             "string-width": "2.1.1",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "cli-table3": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "colors": "1.1.2",
+            "object-assign": "4.1.1",
+            "string-width": "2.1.1"
+          }
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           },
           "dependencies": {
-            "string-width": {
-              "version": "2.1.1",
-              "bundled": true,
-              "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
-              },
-              "dependencies": {
-                "is-fullwidth-code-point": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "strip-ansi": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "3.0.0"
-                  }
-                }
-              }
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
             },
             "strip-ansi": {
-              "version": "3.0.1",
+              "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "2.1.1"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "bundled": true
-                }
+                "ansi-regex": "3.0.0"
               }
             }
           }
         },
-        "cli-table2": {
-          "version": "0.2.0",
-          "bundled": true,
-          "requires": {
-            "colors": "1.1.2",
-            "lodash": "3.10.1",
-            "string-width": "1.0.2"
-          },
-          "dependencies": {
-            "colors": {
-              "version": "1.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              },
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.1.0",
-                  "bundled": true
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "number-is-nan": "1.0.1"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            }
-          }
+        "clone": {
+          "version": "1.0.4",
+          "bundled": true
         },
         "cmd-shim": {
           "version": "2.0.2",
@@ -978,49 +1758,57 @@
             "mkdirp": "0.5.1"
           }
         },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "colors": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true
+        },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
           "requires": {
             "strip-ansi": "3.0.1",
             "wcwidth": "1.0.1"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "bundled": true
-                }
-              }
-            },
-            "wcwidth": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "defaults": "1.0.3"
-              },
-              "dependencies": {
-                "defaults": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "clone": "1.0.2"
-                  },
-                  "dependencies": {
-                    "clone": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            }
+          }
+        },
+        "combined-stream": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "bundled": true,
+          "requires": {
+            "buffer-from": "1.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "typedarray": "0.0.6"
           }
         },
         "config-chain": {
@@ -1029,16 +1817,125 @@
           "requires": {
             "ini": "1.3.5",
             "proto-list": "1.2.4"
+          }
+        },
+        "configstore": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "dot-prop": "4.2.0",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.3.0",
+            "unique-string": "1.0.0",
+            "write-file-atomic": "2.3.0",
+            "xdg-basedir": "3.0.0"
+          }
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "copy-concurrently": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "fs-write-stream-atomic": "1.0.10",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
           },
           "dependencies": {
-            "proto-list": {
-              "version": "1.2.4",
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true
+            }
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "create-error-class": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "capture-stack-trace": "1.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "4.1.3",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
+          }
+        },
+        "crypto-random-string": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cyclist": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
               "bundled": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
+          "bundled": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "defaults": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "clone": "1.0.4"
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
           "bundled": true
         },
         "detect-indent": {
@@ -1053,27 +1950,166 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "asap": "2.0.5",
+            "asap": "2.0.6",
             "wrappy": "1.0.2"
-          },
-          "dependencies": {
-            "asap": {
-              "version": "2.0.5",
-              "bundled": true
-            }
+          }
+        },
+        "dot-prop": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "is-obj": "1.0.1"
+          }
+        },
+        "dotenv": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "duplexer3": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "duplexify": {
+          "version": "3.6.0",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "stream-shift": "1.0.0"
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
           }
         },
         "editor": {
           "version": "1.0.0",
           "bundled": true
         },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.23"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0"
+          }
+        },
+        "err-code": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "errno": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "prr": "1.0.1"
+          }
+        },
+        "es6-promise": {
+          "version": "4.2.4",
+          "bundled": true
+        },
+        "es6-promisify": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "es6-promise": "4.2.4"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
         "figgy-pudding": {
-          "version": "3.1.0",
+          "version": "3.2.0",
           "bundled": true
         },
         "find-npm-prefix": {
           "version": "1.0.2",
           "bundled": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "flush-write-stream": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          }
+        },
+        "from2": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "minipass": "2.3.3"
+          }
         },
         "fs-vacuum": {
           "version": "1.2.10",
@@ -1100,6 +2136,49 @@
             }
           }
         },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "genfun": {
+          "version": "4.0.1",
+          "bundled": true
+        },
         "gentle-fs": {
           "version": "2.0.1",
           "bundled": true,
@@ -1120,6 +2199,27 @@
             }
           }
         },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
@@ -1130,47 +2230,50 @@
             "minimatch": "3.0.4",
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
-          },
-          "dependencies": {
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            }
+          }
+        },
+        "global-dirs": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "ini": "1.3.5"
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "bundled": true,
+          "requires": {
+            "create-error-class": "3.0.2",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.1",
+            "safe-buffer": "5.1.2",
+            "timed-out": "4.0.1",
+            "unzip-response": "2.0.1",
+            "url-parse-lax": "1.0.0"
           }
         },
         "graceful-fs": {
           "version": "4.1.11",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
           "bundled": true
         },
         "has-unicode": {
@@ -1178,11 +2281,65 @@
           "bundled": true
         },
         "hosted-git-info": {
-          "version": "2.6.0",
+          "version": "2.7.1",
           "bundled": true
         },
+        "http-cache-semantics": {
+          "version": "3.8.1",
+          "bundled": true
+        },
+        "http-proxy-agent": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "agent-base": "4.2.0",
+            "debug": "3.1.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.2"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "agent-base": "4.2.0",
+            "debug": "3.1.0"
+          }
+        },
+        "humanize-ms": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "ms": "2.1.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.23",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
         "iferr": {
-          "version": "1.0.0",
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "import-lazy": {
+          "version": "2.1.0",
           "bundled": true
         },
         "imurmurhash": {
@@ -1215,727 +2372,185 @@
             "read": "1.0.7",
             "read-package-json": "2.0.13",
             "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.3",
+            "validate-npm-package-license": "3.0.4",
             "validate-npm-package-name": "3.0.0"
-          },
-          "dependencies": {
-            "promzard": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "read": "1.0.7"
-              }
-            }
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ip": {
+          "version": "1.1.5",
+          "bundled": true
+        },
+        "ip-regex": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-ci": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ci-info": "1.1.3"
           }
         },
         "is-cidr": {
-          "version": "2.0.5",
+          "version": "2.0.6",
           "bundled": true,
           "requires": {
-            "cidr-regex": "2.0.8"
-          },
-          "dependencies": {
-            "cidr-regex": {
-              "version": "2.0.8",
-              "bundled": true,
-              "requires": {
-                "ip-regex": "2.1.0"
-              },
-              "dependencies": {
-                "ip-regex": {
-                  "version": "2.1.0",
-                  "bundled": true
-                }
-              }
-            }
+            "cidr-regex": "2.0.9"
           }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-installed-globally": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "global-dirs": "0.1.1",
+            "is-path-inside": "1.0.1"
+          }
+        },
+        "is-npm": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-path-inside": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "path-is-inside": "1.0.2"
+          }
+        },
+        "is-redirect": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-retry-allowed": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
           "bundled": true
         },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "jsonparse": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "latest-version": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "package-json": "4.0.1"
+          }
+        },
         "lazy-property": {
           "version": "1.0.0",
           "bundled": true
         },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
         "libcipm": {
-          "version": "1.6.2",
+          "version": "2.0.1",
           "bundled": true,
           "requires": {
             "bin-links": "1.1.2",
             "bluebird": "3.5.1",
             "find-npm-prefix": "1.0.2",
             "graceful-fs": "4.1.11",
-            "lock-verify": "2.0.1",
-            "npm-lifecycle": "2.0.1",
+            "lock-verify": "2.0.2",
+            "mkdirp": "0.5.1",
+            "npm-lifecycle": "2.0.3",
             "npm-logical-tree": "1.2.1",
             "npm-package-arg": "6.1.0",
-            "pacote": "7.6.1",
+            "pacote": "8.1.6",
             "protoduck": "5.0.0",
             "read-package-json": "2.0.13",
             "rimraf": "2.6.2",
             "worker-farm": "1.6.0"
-          },
-          "dependencies": {
-            "lock-verify": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "npm-package-arg": "5.1.2",
-                "semver": "5.5.0"
-              },
-              "dependencies": {
-                "npm-package-arg": {
-                  "version": "5.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "hosted-git-info": "2.6.0",
-                    "osenv": "0.1.5",
-                    "semver": "5.5.0",
-                    "validate-npm-package-name": "3.0.0"
-                  }
-                }
-              }
-            },
-            "npm-logical-tree": {
-              "version": "1.2.1",
-              "bundled": true
-            },
-            "pacote": {
-              "version": "7.6.1",
-              "bundled": true,
-              "requires": {
-                "bluebird": "3.5.1",
-                "cacache": "10.0.4",
-                "get-stream": "3.0.0",
-                "glob": "7.1.2",
-                "lru-cache": "4.1.2",
-                "make-fetch-happen": "2.6.0",
-                "minimatch": "3.0.4",
-                "mississippi": "3.0.0",
-                "mkdirp": "0.5.1",
-                "normalize-package-data": "2.4.0",
-                "npm-package-arg": "6.1.0",
-                "npm-packlist": "1.1.10",
-                "npm-pick-manifest": "2.1.0",
-                "osenv": "0.1.5",
-                "promise-inflight": "1.0.1",
-                "promise-retry": "1.1.1",
-                "protoduck": "5.0.0",
-                "rimraf": "2.6.2",
-                "safe-buffer": "5.1.1",
-                "semver": "5.5.0",
-                "ssri": "5.3.0",
-                "tar": "4.4.1",
-                "unique-filename": "1.1.0",
-                "which": "1.3.0"
-              },
-              "dependencies": {
-                "cacache": {
-                  "version": "10.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "bluebird": "3.5.1",
-                    "chownr": "1.0.1",
-                    "glob": "7.1.2",
-                    "graceful-fs": "4.1.11",
-                    "lru-cache": "4.1.2",
-                    "mississippi": "2.0.0",
-                    "mkdirp": "0.5.1",
-                    "move-concurrently": "1.0.1",
-                    "promise-inflight": "1.0.1",
-                    "rimraf": "2.6.2",
-                    "ssri": "5.3.0",
-                    "unique-filename": "1.1.0",
-                    "y18n": "4.0.0"
-                  },
-                  "dependencies": {
-                    "mississippi": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "concat-stream": "1.6.2",
-                        "duplexify": "3.5.4",
-                        "end-of-stream": "1.4.1",
-                        "flush-write-stream": "1.0.3",
-                        "from2": "2.3.0",
-                        "parallel-transform": "1.1.0",
-                        "pump": "2.0.1",
-                        "pumpify": "1.4.0",
-                        "stream-each": "1.2.2",
-                        "through2": "2.0.3"
-                      },
-                      "dependencies": {
-                        "concat-stream": {
-                          "version": "1.6.2",
-                          "bundled": true,
-                          "requires": {
-                            "buffer-from": "1.0.0",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "typedarray": "0.0.6"
-                          },
-                          "dependencies": {
-                            "buffer-from": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "typedarray": {
-                              "version": "0.0.6",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.5.4",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "1.4.1",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "stream-shift": "1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "end-of-stream": {
-                          "version": "1.4.1",
-                          "bundled": true,
-                          "requires": {
-                            "once": "1.4.0"
-                          }
-                        },
-                        "flush-write-stream": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
-                          }
-                        },
-                        "from2": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
-                          }
-                        },
-                        "parallel-transform": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "cyclist": "0.2.2",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
-                          },
-                          "dependencies": {
-                            "cyclist": {
-                              "version": "0.2.2",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "pump": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
-                          }
-                        },
-                        "pumpify": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "requires": {
-                            "duplexify": "3.5.4",
-                            "inherits": "2.0.3",
-                            "pump": "2.0.1"
-                          }
-                        },
-                        "stream-each": {
-                          "version": "1.2.2",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "1.4.1",
-                            "stream-shift": "1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "through2": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "readable-stream": "2.3.6",
-                            "xtend": "4.0.1"
-                          },
-                          "dependencies": {
-                            "xtend": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "y18n": {
-                      "version": "4.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "get-stream": {
-                  "version": "3.0.0",
-                  "bundled": true
-                },
-                "make-fetch-happen": {
-                  "version": "2.6.0",
-                  "bundled": true,
-                  "requires": {
-                    "agentkeepalive": "3.4.1",
-                    "cacache": "10.0.4",
-                    "http-cache-semantics": "3.8.1",
-                    "http-proxy-agent": "2.1.0",
-                    "https-proxy-agent": "2.2.1",
-                    "lru-cache": "4.1.2",
-                    "mississippi": "1.3.1",
-                    "node-fetch-npm": "2.0.2",
-                    "promise-retry": "1.1.1",
-                    "socks-proxy-agent": "3.0.1",
-                    "ssri": "5.3.0"
-                  },
-                  "dependencies": {
-                    "agentkeepalive": {
-                      "version": "3.4.1",
-                      "bundled": true,
-                      "requires": {
-                        "humanize-ms": "1.2.1"
-                      },
-                      "dependencies": {
-                        "humanize-ms": {
-                          "version": "1.2.1",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.1.1"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.1.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "http-cache-semantics": {
-                      "version": "3.8.1",
-                      "bundled": true
-                    },
-                    "http-proxy-agent": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "4.2.0",
-                        "debug": "3.1.0"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "4.2.4"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "3.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "https-proxy-agent": {
-                      "version": "2.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "4.2.0",
-                        "debug": "3.1.0"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "4.2.4"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "3.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "mississippi": {
-                      "version": "1.3.1",
-                      "bundled": true,
-                      "requires": {
-                        "concat-stream": "1.6.2",
-                        "duplexify": "3.5.4",
-                        "end-of-stream": "1.4.1",
-                        "flush-write-stream": "1.0.3",
-                        "from2": "2.3.0",
-                        "parallel-transform": "1.1.0",
-                        "pump": "1.0.3",
-                        "pumpify": "1.4.0",
-                        "stream-each": "1.2.2",
-                        "through2": "2.0.3"
-                      },
-                      "dependencies": {
-                        "concat-stream": {
-                          "version": "1.6.2",
-                          "bundled": true,
-                          "requires": {
-                            "buffer-from": "1.0.0",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "typedarray": "0.0.6"
-                          },
-                          "dependencies": {
-                            "buffer-from": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "typedarray": {
-                              "version": "0.0.6",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.5.4",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "1.4.1",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "stream-shift": "1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "end-of-stream": {
-                          "version": "1.4.1",
-                          "bundled": true,
-                          "requires": {
-                            "once": "1.4.0"
-                          }
-                        },
-                        "flush-write-stream": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
-                          }
-                        },
-                        "from2": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
-                          }
-                        },
-                        "parallel-transform": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "cyclist": "0.2.2",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
-                          },
-                          "dependencies": {
-                            "cyclist": {
-                              "version": "0.2.2",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "pump": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
-                          }
-                        },
-                        "pumpify": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "requires": {
-                            "duplexify": "3.5.4",
-                            "inherits": "2.0.3",
-                            "pump": "2.0.1"
-                          },
-                          "dependencies": {
-                            "pump": {
-                              "version": "2.0.1",
-                              "bundled": true,
-                              "requires": {
-                                "end-of-stream": "1.4.1",
-                                "once": "1.4.0"
-                              }
-                            }
-                          }
-                        },
-                        "stream-each": {
-                          "version": "1.2.2",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "1.4.1",
-                            "stream-shift": "1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "through2": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "readable-stream": "2.3.6",
-                            "xtend": "4.0.1"
-                          },
-                          "dependencies": {
-                            "xtend": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "node-fetch-npm": {
-                      "version": "2.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "encoding": "0.1.12",
-                        "json-parse-better-errors": "1.0.2",
-                        "safe-buffer": "5.1.1"
-                      },
-                      "dependencies": {
-                        "encoding": {
-                          "version": "0.1.12",
-                          "bundled": true,
-                          "requires": {
-                            "iconv-lite": "0.4.21"
-                          },
-                          "dependencies": {
-                            "iconv-lite": {
-                              "version": "0.4.21",
-                              "bundled": true,
-                              "requires": {
-                                "safer-buffer": "2.1.2"
-                              },
-                              "dependencies": {
-                                "safer-buffer": {
-                                  "version": "2.1.2",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks-proxy-agent": {
-                      "version": "3.0.1",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "4.2.0",
-                        "socks": "1.1.10"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "4.2.4"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "socks": {
-                          "version": "1.1.10",
-                          "bundled": true,
-                          "requires": {
-                            "ip": "1.1.5",
-                            "smart-buffer": "1.1.15"
-                          },
-                          "dependencies": {
-                            "ip": {
-                              "version": "1.1.5",
-                              "bundled": true
-                            },
-                            "smart-buffer": {
-                              "version": "1.1.15",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "brace-expansion": "1.1.11"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.11",
-                      "bundled": true,
-                      "requires": {
-                        "balanced-match": "1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "promise-retry": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "err-code": "1.1.2",
-                    "retry": "0.10.1"
-                  },
-                  "dependencies": {
-                    "err-code": {
-                      "version": "1.1.2",
-                      "bundled": true
-                    },
-                    "retry": {
-                      "version": "0.10.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "ssri": {
-                  "version": "5.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "safe-buffer": "5.1.1"
-                  }
-                }
-              }
-            },
-            "protoduck": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "genfun": "4.0.1"
-              },
-              "dependencies": {
-                "genfun": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            }
           }
         },
         "libnpmhook": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "figgy-pudding": "3.1.0",
+            "figgy-pudding": "3.2.0",
             "npm-registry-fetch": "3.1.1"
           },
           "dependencies": {
@@ -1944,248 +2559,10 @@
               "bundled": true,
               "requires": {
                 "bluebird": "3.5.1",
-                "figgy-pudding": "3.1.0",
-                "lru-cache": "4.1.2",
+                "figgy-pudding": "3.2.0",
+                "lru-cache": "4.1.3",
                 "make-fetch-happen": "4.0.1",
                 "npm-package-arg": "6.1.0"
-              },
-              "dependencies": {
-                "make-fetch-happen": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "agentkeepalive": "3.4.1",
-                    "cacache": "11.0.1",
-                    "http-cache-semantics": "3.8.1",
-                    "http-proxy-agent": "2.1.0",
-                    "https-proxy-agent": "2.2.1",
-                    "lru-cache": "4.1.2",
-                    "mississippi": "3.0.0",
-                    "node-fetch-npm": "2.0.2",
-                    "promise-retry": "1.1.1",
-                    "socks-proxy-agent": "4.0.0",
-                    "ssri": "6.0.0"
-                  },
-                  "dependencies": {
-                    "agentkeepalive": {
-                      "version": "3.4.1",
-                      "bundled": true,
-                      "requires": {
-                        "humanize-ms": "1.2.1"
-                      },
-                      "dependencies": {
-                        "humanize-ms": {
-                          "version": "1.2.1",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.1.1"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.1.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "http-cache-semantics": {
-                      "version": "3.8.1",
-                      "bundled": true
-                    },
-                    "http-proxy-agent": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "4.2.0",
-                        "debug": "3.1.0"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "4.2.4"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "3.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "https-proxy-agent": {
-                      "version": "2.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "4.2.0",
-                        "debug": "3.1.0"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "4.2.4"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "3.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "node-fetch-npm": {
-                      "version": "2.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "encoding": "0.1.12",
-                        "json-parse-better-errors": "1.0.2",
-                        "safe-buffer": "5.1.1"
-                      },
-                      "dependencies": {
-                        "encoding": {
-                          "version": "0.1.12",
-                          "bundled": true,
-                          "requires": {
-                            "iconv-lite": "0.4.21"
-                          },
-                          "dependencies": {
-                            "iconv-lite": {
-                              "version": "0.4.21",
-                              "bundled": true,
-                              "requires": {
-                                "safer-buffer": "2.1.2"
-                              },
-                              "dependencies": {
-                                "safer-buffer": {
-                                  "version": "2.1.2",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "promise-retry": {
-                      "version": "1.1.1",
-                      "bundled": true,
-                      "requires": {
-                        "err-code": "1.1.2",
-                        "retry": "0.10.1"
-                      },
-                      "dependencies": {
-                        "err-code": {
-                          "version": "1.1.2",
-                          "bundled": true
-                        },
-                        "retry": {
-                          "version": "0.10.1",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "socks-proxy-agent": {
-                      "version": "4.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "4.1.2",
-                        "socks": "2.1.6"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.1.2",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "4.2.4"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "socks": {
-                          "version": "2.1.6",
-                          "bundled": true,
-                          "requires": {
-                            "ip": "1.1.5",
-                            "smart-buffer": "4.0.1"
-                          },
-                          "dependencies": {
-                            "ip": {
-                              "version": "1.1.5",
-                              "bundled": true
-                            },
-                            "smart-buffer": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
               }
             }
           }
@@ -2197,317 +2574,35 @@
             "dotenv": "5.0.1",
             "npm-package-arg": "6.1.0",
             "rimraf": "2.6.2",
-            "safe-buffer": "5.1.1",
-            "update-notifier": "2.4.0",
-            "which": "1.3.0",
+            "safe-buffer": "5.1.2",
+            "update-notifier": "2.5.0",
+            "which": "1.3.1",
             "y18n": "4.0.0",
             "yargs": "11.0.0"
-          },
-          "dependencies": {
-            "dotenv": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "yargs": {
-              "version": "11.0.0",
-              "bundled": true,
-              "requires": {
-                "cliui": "4.0.0",
-                "decamelize": "1.2.0",
-                "find-up": "2.1.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "9.0.2"
-              },
-              "dependencies": {
-                "cliui": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "2.1.1",
-                    "strip-ansi": "4.0.0",
-                    "wrap-ansi": "2.1.0"
-                  },
-                  "dependencies": {
-                    "wrap-ansi": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1"
-                      },
-                      "dependencies": {
-                        "string-width": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "code-point-at": "1.1.0",
-                            "is-fullwidth-code-point": "1.0.0",
-                            "strip-ansi": "3.0.1"
-                          },
-                          "dependencies": {
-                            "code-point-at": {
-                              "version": "1.1.0",
-                              "bundled": true
-                            },
-                            "is-fullwidth-code-point": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "number-is-nan": "1.0.1"
-                              },
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.1",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "ansi-regex": "2.1.1"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.2.0",
-                  "bundled": true
-                },
-                "find-up": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "locate-path": "2.0.0"
-                  },
-                  "dependencies": {
-                    "locate-path": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "p-locate": "2.0.0",
-                        "path-exists": "3.0.0"
-                      },
-                      "dependencies": {
-                        "p-locate": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "p-limit": "1.2.0"
-                          },
-                          "dependencies": {
-                            "p-limit": {
-                              "version": "1.2.0",
-                              "bundled": true,
-                              "requires": {
-                                "p-try": "1.0.0"
-                              },
-                              "dependencies": {
-                                "p-try": {
-                                  "version": "1.0.0",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "path-exists": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "get-caller-file": {
-                  "version": "1.0.2",
-                  "bundled": true
-                },
-                "os-locale": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "execa": "0.7.0",
-                    "lcid": "1.0.0",
-                    "mem": "1.1.0"
-                  },
-                  "dependencies": {
-                    "execa": {
-                      "version": "0.7.0",
-                      "bundled": true,
-                      "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
-                      },
-                      "dependencies": {
-                        "cross-spawn": {
-                          "version": "5.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "lru-cache": "4.1.2",
-                            "shebang-command": "1.2.0",
-                            "which": "1.3.0"
-                          },
-                          "dependencies": {
-                            "shebang-command": {
-                              "version": "1.2.0",
-                              "bundled": true,
-                              "requires": {
-                                "shebang-regex": "1.0.0"
-                              },
-                              "dependencies": {
-                                "shebang-regex": {
-                                  "version": "1.0.0",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "get-stream": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "npm-run-path": {
-                          "version": "2.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "path-key": "2.0.1"
-                          },
-                          "dependencies": {
-                            "path-key": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "p-finally": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "signal-exit": {
-                          "version": "3.0.2",
-                          "bundled": true
-                        },
-                        "strip-eof": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "lcid": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "invert-kv": "1.0.0"
-                      },
-                      "dependencies": {
-                        "invert-kv": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "mem": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "mimic-fn": "1.2.0"
-                      },
-                      "dependencies": {
-                        "mimic-fn": {
-                          "version": "1.2.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "require-directory": {
-                  "version": "2.1.1",
-                  "bundled": true
-                },
-                "require-main-filename": {
-                  "version": "1.0.1",
-                  "bundled": true
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
-                  },
-                  "dependencies": {
-                    "is-fullwidth-code-point": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "which-module": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "y18n": {
-                  "version": "3.2.1",
-                  "bundled": true
-                },
-                "yargs-parser": {
-                  "version": "9.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "camelcase": "4.1.0"
-                  },
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "4.1.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            }
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
+          }
+        },
+        "lock-verify": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
           }
         },
         "lockfile": {
-          "version": "1.0.3",
-          "bundled": true
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "signal-exit": "3.0.2"
+          }
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
@@ -2519,16 +2614,6 @@
           "requires": {
             "lodash._createset": "4.0.3",
             "lodash._root": "3.0.1"
-          },
-          "dependencies": {
-            "lodash._createset": {
-              "version": "4.0.3",
-              "bundled": true
-            },
-            "lodash._root": {
-              "version": "3.0.1",
-              "bundled": true
-            }
           }
         },
         "lodash._bindcallback": {
@@ -2546,8 +2631,16 @@
             "lodash._getnative": "3.9.1"
           }
         },
+        "lodash._createset": {
+          "version": "4.0.3",
+          "bundled": true
+        },
         "lodash._getnative": {
           "version": "3.9.1",
+          "bundled": true
+        },
+        "lodash._root": {
+          "version": "3.0.1",
           "bundled": true
         },
         "lodash.clonedeep": {
@@ -2570,168 +2663,114 @@
           "version": "4.4.0",
           "bundled": true
         },
+        "lowercase-keys": {
+          "version": "1.0.1",
+          "bundled": true
+        },
         "lru-cache": {
-          "version": "4.1.2",
+          "version": "4.1.3",
           "bundled": true,
           "requires": {
             "pseudomap": "1.0.2",
             "yallist": "2.1.2"
-          },
-          "dependencies": {
-            "pseudomap": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "yallist": {
-              "version": "2.1.2",
-              "bundled": true
-            }
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "pify": "3.0.0"
+          }
+        },
+        "make-fetch-happen": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "agentkeepalive": "3.4.1",
+            "cacache": "11.1.0",
+            "http-cache-semantics": "3.8.1",
+            "http-proxy-agent": "2.1.0",
+            "https-proxy-agent": "2.2.1",
+            "lru-cache": "4.1.3",
+            "mississippi": "3.0.0",
+            "node-fetch-npm": "2.0.2",
+            "promise-retry": "1.1.1",
+            "socks-proxy-agent": "4.0.1",
+            "ssri": "6.0.0"
           }
         },
         "meant": {
           "version": "1.0.1",
           "bundled": true
         },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "1.2.0"
+          }
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.33.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
+          },
+          "dependencies": {
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "minipass": "2.3.3"
+          }
+        },
         "mississippi": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.1",
-            "duplexify": "3.5.4",
+            "concat-stream": "1.6.2",
+            "duplexify": "3.6.0",
             "end-of-stream": "1.4.1",
-            "flush-write-stream": "1.0.2",
+            "flush-write-stream": "1.0.3",
             "from2": "2.3.0",
             "parallel-transform": "1.1.0",
             "pump": "3.0.0",
-            "pumpify": "1.4.0",
+            "pumpify": "1.5.1",
             "stream-each": "1.2.2",
             "through2": "2.0.3"
-          },
-          "dependencies": {
-            "concat-stream": {
-              "version": "1.6.1",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
-              },
-              "dependencies": {
-                "typedarray": {
-                  "version": "0.0.6",
-                  "bundled": true
-                }
-              }
-            },
-            "duplexify": {
-              "version": "3.5.4",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
-              },
-              "dependencies": {
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "end-of-stream": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0"
-              }
-            },
-            "flush-write-stream": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
-              }
-            },
-            "from2": {
-              "version": "2.3.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
-              }
-            },
-            "parallel-transform": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "cyclist": "0.2.2",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
-              },
-              "dependencies": {
-                "cyclist": {
-                  "version": "0.2.2",
-                  "bundled": true
-                }
-              }
-            },
-            "pump": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
-              }
-            },
-            "pumpify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "duplexify": "3.5.4",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
-              },
-              "dependencies": {
-                "pump": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "end-of-stream": "1.4.1",
-                    "once": "1.4.0"
-                  }
-                }
-              }
-            },
-            "stream-each": {
-              "version": "1.2.2",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "1.4.1",
-                "stream-shift": "1.0.0"
-              },
-              "dependencies": {
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "through2": {
-              "version": "2.0.3",
-              "bundled": true,
-              "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
-              },
-              "dependencies": {
-                "xtend": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            }
           }
         },
         "mkdirp": {
@@ -2739,12 +2778,6 @@
           "bundled": true,
           "requires": {
             "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            }
           }
         },
         "move-concurrently": {
@@ -2757,91 +2790,43 @@
             "mkdirp": "0.5.1",
             "rimraf": "2.6.2",
             "run-queue": "1.0.3"
-          },
-          "dependencies": {
-            "copy-concurrently": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "aproba": "1.2.0",
-                "fs-write-stream-atomic": "1.0.10",
-                "iferr": "0.1.5",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
-              },
-              "dependencies": {
-                "iferr": {
-                  "version": "0.1.5",
-                  "bundled": true
-                }
-              }
-            },
-            "run-queue": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "aproba": "1.2.0"
-              }
-            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "node-fetch-npm": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "encoding": "0.1.12",
+            "json-parse-better-errors": "1.0.2",
+            "safe-buffer": "5.1.2"
           }
         },
         "node-gyp": {
-          "version": "3.6.2",
+          "version": "3.8.0",
           "bundled": true,
           "requires": {
             "fstream": "1.0.11",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
-            "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "nopt": "3.0.6",
             "npmlog": "4.1.2",
             "osenv": "0.1.5",
-            "request": "2.85.0",
+            "request": "2.87.0",
             "rimraf": "2.6.2",
             "semver": "5.3.0",
             "tar": "2.2.1",
-            "which": "1.3.0"
+            "which": "1.3.1"
           },
           "dependencies": {
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.11"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.11",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
             "nopt": {
               "version": "3.0.6",
               "bundled": true,
@@ -2860,15 +2845,6 @@
                 "block-stream": "0.0.9",
                 "fstream": "1.0.11",
                 "inherits": "2.0.3"
-              },
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "2.0.3"
-                  }
-                }
               }
             }
           }
@@ -2885,35 +2861,23 @@
           "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.6.0",
+            "hosted-git-info": "2.7.1",
             "is-builtin-module": "1.0.0",
             "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.3"
-          },
-          "dependencies": {
-            "is-builtin-module": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "builtin-modules": "1.1.1"
-              },
-              "dependencies": {
-                "builtin-modules": {
-                  "version": "1.1.1",
-                  "bundled": true
-                }
-              }
-            }
+            "validate-npm-package-license": "3.0.4"
           }
         },
         "npm-audit-report": {
-          "version": "1.0.5",
+          "version": "1.3.1",
           "bundled": true,
           "requires": {
-            "ansicolors": "0.3.2",
-            "ansistyles": "0.1.3",
-            "cli-table2": "0.2.0"
+            "cli-table3": "0.5.0",
+            "console-control-strings": "1.1.0"
           }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true
         },
         "npm-cache-filename": {
           "version": "1.0.2",
@@ -2927,34 +2891,28 @@
           }
         },
         "npm-lifecycle": {
-          "version": "2.0.1",
+          "version": "2.0.3",
           "bundled": true,
           "requires": {
             "byline": "5.0.0",
             "graceful-fs": "4.1.11",
-            "node-gyp": "3.6.2",
+            "node-gyp": "3.8.0",
             "resolve-from": "4.0.0",
             "slide": "1.1.6",
             "uid-number": "0.0.6",
             "umask": "1.1.0",
-            "which": "1.3.0"
-          },
-          "dependencies": {
-            "byline": {
-              "version": "5.0.0",
-              "bundled": true
-            },
-            "resolve-from": {
-              "version": "4.0.0",
-              "bundled": true
-            }
+            "which": "1.3.1"
           }
+        },
+        "npm-logical-tree": {
+          "version": "1.2.1",
+          "bundled": true
         },
         "npm-package-arg": {
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.6.0",
+            "hosted-git-info": "2.7.1",
             "osenv": "0.1.5",
             "semver": "5.5.0",
             "validate-npm-package-name": "3.0.0"
@@ -2966,48 +2924,6 @@
           "requires": {
             "ignore-walk": "3.0.1",
             "npm-bundled": "1.0.3"
-          },
-          "dependencies": {
-            "ignore-walk": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "minimatch": "3.0.4"
-              },
-              "dependencies": {
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "brace-expansion": "1.1.8"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "bundled": true,
-                      "requires": {
-                        "balanced-match": "1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "npm-bundled": {
-              "version": "1.0.3",
-              "bundled": true
-            }
           }
         },
         "npm-pick-manifest": {
@@ -3019,590 +2935,31 @@
           }
         },
         "npm-profile": {
-          "version": "3.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
             "aproba": "1.2.0",
-            "make-fetch-happen": "2.6.0"
-          },
-          "dependencies": {
-            "make-fetch-happen": {
-              "version": "2.6.0",
-              "bundled": true,
-              "requires": {
-                "agentkeepalive": "3.3.0",
-                "cacache": "10.0.4",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.0.0",
-                "https-proxy-agent": "2.1.1",
-                "lru-cache": "4.1.2",
-                "mississippi": "1.3.1",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.3.0"
-              },
-              "dependencies": {
-                "agentkeepalive": {
-                  "version": "3.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "humanize-ms": "1.2.1"
-                  },
-                  "dependencies": {
-                    "humanize-ms": {
-                      "version": "1.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.1.1"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "cacache": {
-                  "version": "10.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "bluebird": "3.5.1",
-                    "chownr": "1.0.1",
-                    "glob": "7.1.2",
-                    "graceful-fs": "4.1.11",
-                    "lru-cache": "4.1.2",
-                    "mississippi": "2.0.0",
-                    "mkdirp": "0.5.1",
-                    "move-concurrently": "1.0.1",
-                    "promise-inflight": "1.0.1",
-                    "rimraf": "2.6.2",
-                    "ssri": "5.3.0",
-                    "unique-filename": "1.1.0",
-                    "y18n": "4.0.0"
-                  },
-                  "dependencies": {
-                    "mississippi": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "concat-stream": "1.6.2",
-                        "duplexify": "3.5.4",
-                        "end-of-stream": "1.4.1",
-                        "flush-write-stream": "1.0.3",
-                        "from2": "2.3.0",
-                        "parallel-transform": "1.1.0",
-                        "pump": "2.0.1",
-                        "pumpify": "1.4.0",
-                        "stream-each": "1.2.2",
-                        "through2": "2.0.3"
-                      },
-                      "dependencies": {
-                        "concat-stream": {
-                          "version": "1.6.2",
-                          "bundled": true,
-                          "requires": {
-                            "buffer-from": "1.0.0",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "typedarray": "0.0.6"
-                          },
-                          "dependencies": {
-                            "buffer-from": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "typedarray": {
-                              "version": "0.0.6",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.5.4",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "1.4.1",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "stream-shift": "1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "end-of-stream": {
-                          "version": "1.4.1",
-                          "bundled": true,
-                          "requires": {
-                            "once": "1.4.0"
-                          }
-                        },
-                        "flush-write-stream": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
-                          }
-                        },
-                        "from2": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
-                          }
-                        },
-                        "parallel-transform": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "cyclist": "0.2.2",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
-                          },
-                          "dependencies": {
-                            "cyclist": {
-                              "version": "0.2.2",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "pump": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
-                          }
-                        },
-                        "pumpify": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "requires": {
-                            "duplexify": "3.5.4",
-                            "inherits": "2.0.3",
-                            "pump": "2.0.1"
-                          }
-                        },
-                        "stream-each": {
-                          "version": "1.2.2",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "1.4.1",
-                            "stream-shift": "1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "through2": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "readable-stream": "2.3.6",
-                            "xtend": "4.0.1"
-                          },
-                          "dependencies": {
-                            "xtend": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "y18n": {
-                      "version": "4.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "http-cache-semantics": {
-                  "version": "3.8.1",
-                  "bundled": true
-                },
-                "http-proxy-agent": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "2.6.9"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.2.4"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "2.6.9",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "https-proxy-agent": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.2.4"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "mississippi": {
-                  "version": "1.3.1",
-                  "bundled": true,
-                  "requires": {
-                    "concat-stream": "1.6.0",
-                    "duplexify": "3.5.3",
-                    "end-of-stream": "1.4.1",
-                    "flush-write-stream": "1.0.2",
-                    "from2": "2.3.0",
-                    "parallel-transform": "1.1.0",
-                    "pump": "1.0.3",
-                    "pumpify": "1.4.0",
-                    "stream-each": "1.2.2",
-                    "through2": "2.0.3"
-                  },
-                  "dependencies": {
-                    "concat-stream": {
-                      "version": "1.6.0",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "typedarray": "0.0.6"
-                      },
-                      "dependencies": {
-                        "typedarray": {
-                          "version": "0.0.6",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "duplexify": {
-                      "version": "3.5.3",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "1.4.1",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "stream-shift": "1.0.0"
-                      },
-                      "dependencies": {
-                        "stream-shift": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "end-of-stream": {
-                      "version": "1.4.1",
-                      "bundled": true,
-                      "requires": {
-                        "once": "1.4.0"
-                      }
-                    },
-                    "flush-write-stream": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
-                      }
-                    },
-                    "from2": {
-                      "version": "2.3.0",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
-                      }
-                    },
-                    "parallel-transform": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "cyclist": "0.2.2",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
-                      },
-                      "dependencies": {
-                        "cyclist": {
-                          "version": "0.2.2",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "pump": {
-                      "version": "1.0.3",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "1.4.1",
-                        "once": "1.4.0"
-                      }
-                    },
-                    "pumpify": {
-                      "version": "1.4.0",
-                      "bundled": true,
-                      "requires": {
-                        "duplexify": "3.5.3",
-                        "inherits": "2.0.3",
-                        "pump": "2.0.1"
-                      },
-                      "dependencies": {
-                        "pump": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
-                          }
-                        }
-                      }
-                    },
-                    "stream-each": {
-                      "version": "1.2.2",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "1.4.1",
-                        "stream-shift": "1.0.0"
-                      },
-                      "dependencies": {
-                        "stream-shift": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "through2": {
-                      "version": "2.0.3",
-                      "bundled": true,
-                      "requires": {
-                        "readable-stream": "2.3.6",
-                        "xtend": "4.0.1"
-                      },
-                      "dependencies": {
-                        "xtend": {
-                          "version": "4.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "node-fetch-npm": {
-                  "version": "2.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.1",
-                    "safe-buffer": "5.1.1"
-                  },
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "bundled": true,
-                      "requires": {
-                        "iconv-lite": "0.4.19"
-                      },
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.19",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "json-parse-better-errors": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "promise-retry": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "err-code": "1.1.2",
-                    "retry": "0.10.1"
-                  },
-                  "dependencies": {
-                    "err-code": {
-                      "version": "1.1.2",
-                      "bundled": true
-                    },
-                    "retry": {
-                      "version": "0.10.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "socks-proxy-agent": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "1.1.10"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.2.4"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks": {
-                      "version": "1.1.10",
-                      "bundled": true,
-                      "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
-                      },
-                      "dependencies": {
-                        "ip": {
-                          "version": "1.1.5",
-                          "bundled": true
-                        },
-                        "smart-buffer": {
-                          "version": "1.1.15",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "ssri": {
-                  "version": "5.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "safe-buffer": "5.1.1"
-                  }
-                }
-              }
-            }
+            "make-fetch-happen": "4.0.1"
           }
         },
         "npm-registry-client": {
           "version": "8.5.1",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.1",
+            "concat-stream": "1.6.2",
             "graceful-fs": "4.1.11",
             "normalize-package-data": "2.4.0",
             "npm-package-arg": "6.1.0",
             "npmlog": "4.1.2",
             "once": "1.4.0",
-            "request": "2.85.0",
+            "request": "2.87.0",
             "retry": "0.10.1",
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.1.2",
             "semver": "5.5.0",
             "slide": "1.1.6",
             "ssri": "5.3.0"
           },
           "dependencies": {
-            "concat-stream": {
-              "version": "1.6.1",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
-              },
-              "dependencies": {
-                "typedarray": {
-                  "version": "0.0.6",
-                  "bundled": true
-                }
-              }
-            },
             "retry": {
               "version": "0.10.1",
               "bundled": true
@@ -3611,7 +2968,7 @@
               "version": "5.3.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -3622,12 +2979,49 @@
           "requires": {
             "bluebird": "3.5.1",
             "figgy-pudding": "2.0.1",
-            "lru-cache": "4.1.2",
+            "lru-cache": "4.1.3",
             "make-fetch-happen": "3.0.0",
             "npm-package-arg": "6.1.0",
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "5.1.2"
           },
           "dependencies": {
+            "cacache": {
+              "version": "10.0.4",
+              "bundled": true,
+              "requires": {
+                "bluebird": "3.5.1",
+                "chownr": "1.0.1",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lru-cache": "4.1.3",
+                "mississippi": "2.0.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.2",
+                "ssri": "5.3.0",
+                "unique-filename": "1.1.0",
+                "y18n": "4.0.0"
+              },
+              "dependencies": {
+                "mississippi": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "concat-stream": "1.6.2",
+                    "duplexify": "3.6.0",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.3",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "2.0.1",
+                    "pumpify": "1.5.1",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
+                  }
+                }
+              }
+            },
             "figgy-pudding": {
               "version": "2.0.1",
               "bundled": true
@@ -3641,402 +3035,56 @@
                 "http-cache-semantics": "3.8.1",
                 "http-proxy-agent": "2.1.0",
                 "https-proxy-agent": "2.2.1",
-                "lru-cache": "4.1.2",
+                "lru-cache": "4.1.3",
                 "mississippi": "3.0.0",
                 "node-fetch-npm": "2.0.2",
                 "promise-retry": "1.1.1",
                 "socks-proxy-agent": "3.0.1",
                 "ssri": "5.3.0"
-              },
-              "dependencies": {
-                "agentkeepalive": {
-                  "version": "3.4.1",
-                  "bundled": true,
-                  "requires": {
-                    "humanize-ms": "1.2.1"
-                  },
-                  "dependencies": {
-                    "humanize-ms": {
-                      "version": "1.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.1.1"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "cacache": {
-                  "version": "10.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "bluebird": "3.5.1",
-                    "chownr": "1.0.1",
-                    "glob": "7.1.2",
-                    "graceful-fs": "4.1.11",
-                    "lru-cache": "4.1.2",
-                    "mississippi": "2.0.0",
-                    "mkdirp": "0.5.1",
-                    "move-concurrently": "1.0.1",
-                    "promise-inflight": "1.0.1",
-                    "rimraf": "2.6.2",
-                    "ssri": "5.3.0",
-                    "unique-filename": "1.1.0",
-                    "y18n": "4.0.0"
-                  },
-                  "dependencies": {
-                    "mississippi": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "concat-stream": "1.6.2",
-                        "duplexify": "3.5.4",
-                        "end-of-stream": "1.4.1",
-                        "flush-write-stream": "1.0.3",
-                        "from2": "2.3.0",
-                        "parallel-transform": "1.1.0",
-                        "pump": "2.0.1",
-                        "pumpify": "1.4.0",
-                        "stream-each": "1.2.2",
-                        "through2": "2.0.3"
-                      },
-                      "dependencies": {
-                        "concat-stream": {
-                          "version": "1.6.2",
-                          "bundled": true,
-                          "requires": {
-                            "buffer-from": "1.0.0",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "typedarray": "0.0.6"
-                          },
-                          "dependencies": {
-                            "buffer-from": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "typedarray": {
-                              "version": "0.0.6",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.5.4",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "1.4.1",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "stream-shift": "1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "end-of-stream": {
-                          "version": "1.4.1",
-                          "bundled": true,
-                          "requires": {
-                            "once": "1.4.0"
-                          }
-                        },
-                        "flush-write-stream": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
-                          }
-                        },
-                        "from2": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
-                          }
-                        },
-                        "parallel-transform": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "cyclist": "0.2.2",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
-                          },
-                          "dependencies": {
-                            "cyclist": {
-                              "version": "0.2.2",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "pump": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
-                          }
-                        },
-                        "pumpify": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "requires": {
-                            "duplexify": "3.5.4",
-                            "inherits": "2.0.3",
-                            "pump": "2.0.1"
-                          }
-                        },
-                        "stream-each": {
-                          "version": "1.2.2",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "1.4.1",
-                            "stream-shift": "1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "through2": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "readable-stream": "2.3.6",
-                            "xtend": "4.0.1"
-                          },
-                          "dependencies": {
-                            "xtend": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "y18n": {
-                      "version": "4.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "http-cache-semantics": {
-                  "version": "3.8.1",
-                  "bundled": true
-                },
-                "http-proxy-agent": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.2.4"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "https-proxy-agent": {
-                  "version": "2.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.2.4"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "node-fetch-npm": {
-                  "version": "2.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.2",
-                    "safe-buffer": "5.1.1"
-                  },
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "bundled": true,
-                      "requires": {
-                        "iconv-lite": "0.4.21"
-                      },
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.21",
-                          "bundled": true,
-                          "requires": {
-                            "safer-buffer": "2.1.2"
-                          },
-                          "dependencies": {
-                            "safer-buffer": {
-                              "version": "2.1.2",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "promise-retry": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "err-code": "1.1.2",
-                    "retry": "0.10.1"
-                  },
-                  "dependencies": {
-                    "err-code": {
-                      "version": "1.1.2",
-                      "bundled": true
-                    },
-                    "retry": {
-                      "version": "0.10.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "socks-proxy-agent": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "1.1.10"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.2.4"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks": {
-                      "version": "1.1.10",
-                      "bundled": true,
-                      "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
-                      },
-                      "dependencies": {
-                        "ip": {
-                          "version": "1.1.5",
-                          "bundled": true
-                        },
-                        "smart-buffer": {
-                          "version": "1.1.15",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "ssri": {
-                  "version": "5.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "safe-buffer": "5.1.1"
-                  }
-                }
+              }
+            },
+            "pump": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+              }
+            },
+            "smart-buffer": {
+              "version": "1.1.15",
+              "bundled": true
+            },
+            "socks": {
+              "version": "1.1.10",
+              "bundled": true,
+              "requires": {
+                "ip": "1.1.5",
+                "smart-buffer": "1.1.15"
+              }
+            },
+            "socks-proxy-agent": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "agent-base": "4.2.0",
+                "socks": "1.1.10"
+              }
+            },
+            "ssri": {
+              "version": "5.3.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.2"
               }
             }
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "path-key": "2.0.1"
           }
         },
         "npm-user-validate": {
@@ -4051,103 +3099,19 @@
             "console-control-strings": "1.1.0",
             "gauge": "2.7.4",
             "set-blocking": "2.0.0"
-          },
-          "dependencies": {
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "bundled": true,
-              "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.6"
-              },
-              "dependencies": {
-                "delegates": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
-              },
-              "dependencies": {
-                "object-assign": {
-                  "version": "4.1.1",
-                  "bundled": true
-                },
-                "signal-exit": {
-                  "version": "3.0.2",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  },
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.1.0",
-                      "bundled": true
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "number-is-nan": "1.0.1"
-                      },
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "wide-align": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "1.0.2"
-                  }
-                }
-              }
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true
-            }
           }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
@@ -4160,35 +3124,75 @@
           "version": "1.4.3",
           "bundled": true
         },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
-          },
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true
-            }
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "1.2.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "package-json": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "got": "6.7.1",
+            "registry-auth-token": "3.3.2",
+            "registry-url": "3.1.0",
+            "semver": "5.5.0"
           }
         },
         "pacote": {
-          "version": "8.1.0",
+          "version": "8.1.6",
           "bundled": true,
           "requires": {
             "bluebird": "3.5.1",
-            "cacache": "11.0.1",
+            "cacache": "11.1.0",
             "get-stream": "3.0.0",
             "glob": "7.1.2",
-            "lru-cache": "4.1.2",
+            "lru-cache": "4.1.3",
             "make-fetch-happen": "4.0.1",
             "minimatch": "3.0.4",
+            "minipass": "2.3.3",
             "mississippi": "3.0.0",
             "mkdirp": "0.5.1",
             "normalize-package-data": "2.4.0",
@@ -4200,341 +3204,171 @@
             "promise-retry": "1.1.1",
             "protoduck": "5.0.0",
             "rimraf": "2.6.2",
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.1.2",
             "semver": "5.5.0",
             "ssri": "6.0.0",
-            "tar": "4.4.1",
+            "tar": "4.4.6",
             "unique-filename": "1.1.0",
-            "which": "1.3.0"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "3.0.0",
-              "bundled": true
-            },
-            "make-fetch-happen": {
-              "version": "4.0.1",
-              "bundled": true,
-              "requires": {
-                "agentkeepalive": "3.4.1",
-                "cacache": "11.0.1",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.1.0",
-                "https-proxy-agent": "2.2.1",
-                "lru-cache": "4.1.2",
-                "mississippi": "3.0.0",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "4.0.1",
-                "ssri": "6.0.0"
-              },
-              "dependencies": {
-                "agentkeepalive": {
-                  "version": "3.4.1",
-                  "bundled": true,
-                  "requires": {
-                    "humanize-ms": "1.2.1"
-                  },
-                  "dependencies": {
-                    "humanize-ms": {
-                      "version": "1.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.1.1"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "http-cache-semantics": {
-                  "version": "3.8.1",
-                  "bundled": true
-                },
-                "http-proxy-agent": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.2.4"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "https-proxy-agent": {
-                  "version": "2.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.2.4"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "node-fetch-npm": {
-                  "version": "2.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.2",
-                    "safe-buffer": "5.1.1"
-                  },
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "bundled": true,
-                      "requires": {
-                        "iconv-lite": "0.4.21"
-                      },
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.21",
-                          "bundled": true,
-                          "requires": {
-                            "safer-buffer": "2.1.2"
-                          },
-                          "dependencies": {
-                            "safer-buffer": {
-                              "version": "2.1.2",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "socks-proxy-agent": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "2.2.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.2.4"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks": {
-                      "version": "2.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "4.0.1"
-                      },
-                      "dependencies": {
-                        "ip": {
-                          "version": "1.1.5",
-                          "bundled": true
-                        },
-                        "smart-buffer": {
-                          "version": "4.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.11"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.11",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "promise-retry": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "err-code": "1.1.2",
-                "retry": "0.10.1"
-              },
-              "dependencies": {
-                "err-code": {
-                  "version": "1.1.2",
-                  "bundled": true
-                },
-                "retry": {
-                  "version": "0.10.1",
-                  "bundled": true
-                }
-              }
-            },
-            "protoduck": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "genfun": "4.0.1"
-              },
-              "dependencies": {
-                "genfun": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            }
+            "which": "1.3.1"
           }
+        },
+        "parallel-transform": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "cyclist": "0.2.2",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
         },
         "path-is-inside": {
           "version": "1.0.2",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
           "bundled": true
         },
         "promise-inflight": {
           "version": "1.0.1",
           "bundled": true
         },
+        "promise-retry": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "err-code": "1.1.2",
+            "retry": "0.10.1"
+          },
+          "dependencies": {
+            "retry": {
+              "version": "0.10.1",
+              "bundled": true
+            }
+          }
+        },
+        "promzard": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "read": "1.0.7"
+          }
+        },
+        "proto-list": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "protoduck": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "genfun": "4.0.1"
+          }
+        },
+        "prr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "pump": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        },
+        "pumpify": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "duplexify": "3.6.0",
+            "inherits": "2.0.3",
+            "pump": "2.0.1"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+              }
+            }
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
         "qrcode-terminal": {
           "version": "0.12.0",
           "bundled": true
         },
+        "qs": {
+          "version": "6.5.2",
+          "bundled": true
+        },
         "query-string": {
-          "version": "6.0.0",
+          "version": "6.1.0",
           "bundled": true,
           "requires": {
             "decode-uri-component": "0.2.0",
             "strict-uri-encode": "2.0.0"
-          },
-          "dependencies": {
-            "decode-uri-component": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "strict-uri-encode": {
-              "version": "2.0.0",
-              "bundled": true
-            }
           }
         },
         "qw": {
           "version": "1.0.1",
           "bundled": true
         },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
         "read": {
           "version": "1.0.7",
           "bundled": true,
           "requires": {
             "mute-stream": "0.0.7"
-          },
-          "dependencies": {
-            "mute-stream": {
-              "version": "0.0.7",
-              "bundled": true
-            }
           }
         },
         "read-cmd-shim": {
@@ -4555,12 +3389,6 @@
             "semver": "5.5.0",
             "slide": "1.1.6",
             "util-extend": "1.0.3"
-          },
-          "dependencies": {
-            "util-extend": {
-              "version": "1.0.3",
-              "bundled": true
-            }
           }
         },
         "read-package-json": {
@@ -4569,19 +3397,9 @@
           "requires": {
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
-            "json-parse-better-errors": "1.0.1",
+            "json-parse-better-errors": "1.0.2",
             "normalize-package-data": "2.4.0",
             "slash": "1.0.0"
-          },
-          "dependencies": {
-            "json-parse-better-errors": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "slash": {
-              "version": "1.0.0",
-              "bundled": true
-            }
           }
         },
         "read-package-tree": {
@@ -4603,34 +3421,9 @@
             "inherits": "2.0.3",
             "isarray": "1.0.0",
             "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.1.2",
             "string_decoder": "1.1.1",
             "util-deprecate": "1.0.2"
-          },
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "process-nextick-args": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            }
           }
         },
         "readdir-scoped-modules": {
@@ -4643,19 +3436,33 @@
             "once": "1.4.0"
           }
         },
+        "registry-auth-token": {
+          "version": "3.3.2",
+          "bundled": true,
+          "requires": {
+            "rc": "1.2.7",
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "registry-url": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "rc": "1.2.7"
+          }
+        },
         "request": {
-          "version": "2.85.0",
+          "version": "2.87.0",
           "bundled": true,
           "requires": {
             "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
+            "aws4": "1.7.0",
             "caseless": "0.12.0",
             "combined-stream": "1.0.6",
             "extend": "3.0.1",
             "forever-agent": "0.6.1",
             "form-data": "2.3.2",
             "har-validator": "5.0.3",
-            "hawk": "6.0.2",
             "http-signature": "1.2.0",
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
@@ -4663,322 +3470,24 @@
             "mime-types": "2.1.18",
             "oauth-sign": "0.8.2",
             "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.2",
             "tough-cookie": "2.3.4",
             "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          },
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              },
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.2",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
-              },
-              "dependencies": {
-                "asynckit": {
-                  "version": "0.4.0",
-                  "bundled": true
-                }
-              }
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
-              },
-              "dependencies": {
-                "ajv": {
-                  "version": "5.5.2",
-                  "bundled": true,
-                  "requires": {
-                    "co": "4.6.0",
-                    "fast-deep-equal": "1.1.0",
-                    "fast-json-stable-stringify": "2.0.0",
-                    "json-schema-traverse": "0.3.1"
-                  },
-                  "dependencies": {
-                    "co": {
-                      "version": "4.6.0",
-                      "bundled": true
-                    },
-                    "fast-deep-equal": {
-                      "version": "1.1.0",
-                      "bundled": true
-                    },
-                    "fast-json-stable-stringify": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    },
-                    "json-schema-traverse": {
-                      "version": "0.3.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "har-schema": {
-                  "version": "2.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.1",
-                "sntp": "2.1.0"
-              },
-              "dependencies": {
-                "boom": {
-                  "version": "4.3.1",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "4.2.1"
-                  }
-                },
-                "cryptiles": {
-                  "version": "3.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "boom": "5.2.0"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "5.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "hoek": "4.2.1"
-                      }
-                    }
-                  }
-                },
-                "hoek": {
-                  "version": "4.2.1",
-                  "bundled": true
-                },
-                "sntp": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "4.2.1"
-                  }
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "jsprim": {
-                  "version": "1.4.1",
-                  "bundled": true,
-                  "requires": {
-                    "assert-plus": "1.0.0",
-                    "extsprintf": "1.3.0",
-                    "json-schema": "0.2.3",
-                    "verror": "1.10.0"
-                  },
-                  "dependencies": {
-                    "extsprintf": {
-                      "version": "1.3.0",
-                      "bundled": true
-                    },
-                    "json-schema": {
-                      "version": "0.2.3",
-                      "bundled": true
-                    },
-                    "verror": {
-                      "version": "1.10.0",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "extsprintf": "1.3.0"
-                      },
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.14.1",
-                  "bundled": true,
-                  "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "1.0.0",
-                    "bcrypt-pbkdf": "1.0.1",
-                    "dashdash": "1.14.1",
-                    "ecc-jsbn": "0.1.1",
-                    "getpass": "0.1.7",
-                    "jsbn": "0.1.1",
-                    "tweetnacl": "0.14.5"
-                  },
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "bundled": true
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.1",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "tweetnacl": "0.14.5"
-                      }
-                    },
-                    "dashdash": {
-                      "version": "1.14.1",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "1.0.0"
-                      }
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "jsbn": "0.1.1"
-                      }
-                    },
-                    "getpass": {
-                      "version": "0.1.7",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "1.0.0"
-                      }
-                    },
-                    "jsbn": {
-                      "version": "0.1.1",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.5",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.18",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.33.0"
-              },
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.33.0",
-                  "bundled": true
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.4",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              },
-              "dependencies": {
-                "punycode": {
-                  "version": "1.4.1",
-                  "bundled": true
-                }
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
+            "uuid": "3.3.2"
           }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "bundled": true
         },
         "retry": {
           "version": "0.12.0",
@@ -4991,12 +3500,34 @@
             "glob": "7.1.2"
           }
         },
+        "run-queue": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0"
+          }
+        },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
           "bundled": true
         },
         "semver": {
           "version": "5.5.0",
+          "bundled": true
+        },
+        "semver-diff": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "semver": "5.5.0"
+          }
+        },
+        "set-blocking": {
+          "version": "2.0.0",
           "bundled": true
         },
         "sha": {
@@ -5007,9 +3538,48 @@
             "readable-stream": "2.3.6"
           }
         },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true
+        },
         "slide": {
           "version": "1.1.6",
           "bundled": true
+        },
+        "smart-buffer": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "socks": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "ip": "1.1.5",
+            "smart-buffer": "4.0.1"
+          }
+        },
+        "socks-proxy-agent": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "agent-base": "4.2.0",
+            "socks": "2.2.0"
+          }
         },
         "sorted-object": {
           "version": "2.0.1",
@@ -5029,47 +3599,70 @@
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "1.1.14"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.14",
-                  "bundled": true,
-                  "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "bundled": true
-                    }
-                  }
-                }
               }
             },
-            "stream-iterate": {
-              "version": "1.2.0",
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
               "bundled": true,
               "requires": {
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
-              },
-              "dependencies": {
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
               }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true
+            }
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "sshpk": {
+          "version": "1.14.2",
+          "bundled": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.2",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "safer-buffer": "2.1.2",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
             }
           }
         },
@@ -5077,66 +3670,159 @@
           "version": "6.0.0",
           "bundled": true
         },
-        "strip-ansi": {
-          "version": "4.0.0",
+        "stream-each": {
+          "version": "1.2.2",
           "bundled": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "end-of-stream": "1.4.1",
+            "stream-shift": "1.0.0"
+          }
+        },
+        "stream-iterate": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "2.3.6",
+            "stream-shift": "1.0.0"
+          }
+        },
+        "stream-shift": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
               "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
             }
           }
         },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "stringify-package": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.6",
           "bundled": true,
           "requires": {
             "chownr": "1.0.1",
             "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
+            "minipass": "2.3.3",
             "minizlib": "1.1.0",
             "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.1.2",
             "yallist": "3.0.2"
           },
           "dependencies": {
-            "fs-minipass": {
-              "version": "1.2.5",
-              "bundled": true,
-              "requires": {
-                "minipass": "2.2.4"
-              }
-            },
-            "minipass": {
-              "version": "2.2.4",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1",
-                "yallist": "3.0.2"
-              }
-            },
-            "minizlib": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "minipass": "2.2.4"
-              }
-            },
             "yallist": {
               "version": "3.0.2",
               "bundled": true
             }
           }
         },
+        "term-size": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "execa": "0.7.0"
+          }
+        },
         "text-table": {
           "version": "0.2.0",
           "bundled": true
         },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          }
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "bundled": true
+        },
         "tiny-relative-date": {
           "version": "1.3.0",
+          "bundled": true
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "typedarray": {
+          "version": "0.0.6",
           "bundled": true
         },
         "uid-number": {
@@ -5152,27 +3838,36 @@
           "bundled": true,
           "requires": {
             "unique-slug": "2.0.0"
-          },
-          "dependencies": {
-            "unique-slug": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "imurmurhash": "0.1.4"
-              }
-            }
+          }
+        },
+        "unique-slug": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "imurmurhash": "0.1.4"
+          }
+        },
+        "unique-string": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "crypto-random-string": "1.0.0"
           }
         },
         "unpipe": {
           "version": "1.0.0",
           "bundled": true
         },
+        "unzip-response": {
+          "version": "2.0.1",
+          "bundled": true
+        },
         "update-notifier": {
-          "version": "2.4.0",
+          "version": "2.5.0",
           "bundled": true,
           "requires": {
             "boxen": "1.3.0",
-            "chalk": "2.3.2",
+            "chalk": "2.4.1",
             "configstore": "3.1.2",
             "import-lazy": "2.1.0",
             "is-ci": "1.1.0",
@@ -5181,510 +3876,33 @@
             "latest-version": "3.1.0",
             "semver-diff": "2.1.0",
             "xdg-basedir": "3.0.0"
-          },
-          "dependencies": {
-            "boxen": {
-              "version": "1.3.0",
-              "bundled": true,
-              "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "2.3.2",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.1",
-                "term-size": "1.2.0",
-                "widest-line": "2.0.0"
-              },
-              "dependencies": {
-                "ansi-align": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "2.1.1"
-                  }
-                },
-                "camelcase": {
-                  "version": "4.1.0",
-                  "bundled": true
-                },
-                "cli-boxes": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
-                  },
-                  "dependencies": {
-                    "is-fullwidth-code-point": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "term-size": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "execa": "0.7.0"
-                  },
-                  "dependencies": {
-                    "execa": {
-                      "version": "0.7.0",
-                      "bundled": true,
-                      "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
-                      },
-                      "dependencies": {
-                        "cross-spawn": {
-                          "version": "5.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "lru-cache": "4.1.2",
-                            "shebang-command": "1.2.0",
-                            "which": "1.3.0"
-                          },
-                          "dependencies": {
-                            "shebang-command": {
-                              "version": "1.2.0",
-                              "bundled": true,
-                              "requires": {
-                                "shebang-regex": "1.0.0"
-                              },
-                              "dependencies": {
-                                "shebang-regex": {
-                                  "version": "1.0.0",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "get-stream": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "npm-run-path": {
-                          "version": "2.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "path-key": "2.0.1"
-                          },
-                          "dependencies": {
-                            "path-key": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "p-finally": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "signal-exit": {
-                          "version": "3.0.2",
-                          "bundled": true
-                        },
-                        "strip-eof": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "widest-line": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "2.1.1"
-                  }
-                }
-              }
-            },
-            "chalk": {
-              "version": "2.3.2",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.3.0"
-              },
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "3.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "color-convert": "1.9.1"
-                  },
-                  "dependencies": {
-                    "color-convert": {
-                      "version": "1.9.1",
-                      "bundled": true,
-                      "requires": {
-                        "color-name": "1.1.3"
-                      },
-                      "dependencies": {
-                        "color-name": {
-                          "version": "1.1.3",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "bundled": true
-                },
-                "supports-color": {
-                  "version": "5.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "has-flag": "3.0.0"
-                  },
-                  "dependencies": {
-                    "has-flag": {
-                      "version": "3.0.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "configstore": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "dot-prop": "4.2.0",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.2.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.3.0",
-                "xdg-basedir": "3.0.0"
-              },
-              "dependencies": {
-                "dot-prop": {
-                  "version": "4.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "is-obj": "1.0.1"
-                  },
-                  "dependencies": {
-                    "is-obj": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "make-dir": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "pify": "3.0.0"
-                  },
-                  "dependencies": {
-                    "pify": {
-                      "version": "3.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "unique-string": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "crypto-random-string": "1.0.0"
-                  },
-                  "dependencies": {
-                    "crypto-random-string": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "import-lazy": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "is-ci": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "ci-info": "1.1.3"
-              },
-              "dependencies": {
-                "ci-info": {
-                  "version": "1.1.3",
-                  "bundled": true
-                }
-              }
-            },
-            "is-installed-globally": {
-              "version": "0.1.0",
-              "bundled": true,
-              "requires": {
-                "global-dirs": "0.1.1",
-                "is-path-inside": "1.0.1"
-              },
-              "dependencies": {
-                "global-dirs": {
-                  "version": "0.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "ini": "1.3.5"
-                  }
-                },
-                "is-path-inside": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "path-is-inside": "1.0.2"
-                  }
-                }
-              }
-            },
-            "is-npm": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "latest-version": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "package-json": "4.0.1"
-              },
-              "dependencies": {
-                "package-json": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "got": "6.7.1",
-                    "registry-auth-token": "3.3.2",
-                    "registry-url": "3.1.0",
-                    "semver": "5.5.0"
-                  },
-                  "dependencies": {
-                    "got": {
-                      "version": "6.7.1",
-                      "bundled": true,
-                      "requires": {
-                        "create-error-class": "3.0.2",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "is-redirect": "1.0.0",
-                        "is-retry-allowed": "1.1.0",
-                        "is-stream": "1.1.0",
-                        "lowercase-keys": "1.0.1",
-                        "safe-buffer": "5.1.1",
-                        "timed-out": "4.0.1",
-                        "unzip-response": "2.0.1",
-                        "url-parse-lax": "1.0.0"
-                      },
-                      "dependencies": {
-                        "create-error-class": {
-                          "version": "3.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "capture-stack-trace": "1.0.0"
-                          },
-                          "dependencies": {
-                            "capture-stack-trace": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexer3": {
-                          "version": "0.1.4",
-                          "bundled": true
-                        },
-                        "get-stream": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        },
-                        "is-redirect": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "is-retry-allowed": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "lowercase-keys": {
-                          "version": "1.0.1",
-                          "bundled": true
-                        },
-                        "timed-out": {
-                          "version": "4.0.1",
-                          "bundled": true
-                        },
-                        "unzip-response": {
-                          "version": "2.0.1",
-                          "bundled": true
-                        },
-                        "url-parse-lax": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "prepend-http": "1.0.4"
-                          },
-                          "dependencies": {
-                            "prepend-http": {
-                              "version": "1.0.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "registry-auth-token": {
-                      "version": "3.3.2",
-                      "bundled": true,
-                      "requires": {
-                        "rc": "1.2.6",
-                        "safe-buffer": "5.1.1"
-                      },
-                      "dependencies": {
-                        "rc": {
-                          "version": "1.2.6",
-                          "bundled": true,
-                          "requires": {
-                            "deep-extend": "0.4.2",
-                            "ini": "1.3.5",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
-                          },
-                          "dependencies": {
-                            "deep-extend": {
-                              "version": "0.4.2",
-                              "bundled": true
-                            },
-                            "minimist": {
-                              "version": "1.2.0",
-                              "bundled": true
-                            },
-                            "strip-json-comments": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "registry-url": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "rc": "1.2.6"
-                      },
-                      "dependencies": {
-                        "rc": {
-                          "version": "1.2.6",
-                          "bundled": true,
-                          "requires": {
-                            "deep-extend": "0.4.2",
-                            "ini": "1.3.5",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
-                          },
-                          "dependencies": {
-                            "deep-extend": {
-                              "version": "0.4.2",
-                              "bundled": true
-                            },
-                            "minimist": {
-                              "version": "1.2.0",
-                              "bundled": true
-                            },
-                            "strip-json-comments": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "semver-diff": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "semver": "5.5.0"
-              }
-            },
-            "xdg-basedir": {
-              "version": "3.0.0",
-              "bundled": true
-            }
           }
         },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "prepend-http": "1.0.4"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "util-extend": {
+          "version": "1.0.3",
+          "bundled": true
+        },
         "uuid": {
-          "version": "3.2.1",
+          "version": "3.3.2",
           "bundled": true
         },
         "validate-npm-package-license": {
-          "version": "3.0.3",
+          "version": "3.0.4",
           "bundled": true,
           "requires": {
             "spdx-correct": "3.0.0",
             "spdx-expression-parse": "3.0.0"
-          },
-          "dependencies": {
-            "spdx-correct": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
-              },
-              "dependencies": {
-                "spdx-license-ids": {
-                  "version": "3.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "spdx-expression-parse": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
-              },
-              "dependencies": {
-                "spdx-exceptions": {
-                  "version": "2.1.0",
-                  "bundled": true
-                },
-                "spdx-license-ids": {
-                  "version": "3.0.0",
-                  "bundled": true
-                }
-              }
-            }
           }
         },
         "validate-npm-package-name": {
@@ -5692,25 +3910,64 @@
           "bundled": true,
           "requires": {
             "builtins": "1.0.3"
+          }
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "1.3.0"
           },
           "dependencies": {
-            "builtins": {
-              "version": "1.0.3",
+            "assert-plus": {
+              "version": "1.0.0",
               "bundled": true
             }
           }
         },
+        "wcwidth": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "defaults": "1.0.3"
+          }
+        },
         "which": {
-          "version": "1.3.0",
+          "version": "1.3.1",
           "bundled": true,
           "requires": {
             "isexe": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2"
           },
           "dependencies": {
-            "isexe": {
-              "version": "2.0.0",
-              "bundled": true
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
             }
+          }
+        },
+        "widest-line": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "2.1.1"
           }
         },
         "worker-farm": {
@@ -5718,19 +3975,23 @@
           "bundled": true,
           "requires": {
             "errno": "0.1.7"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
           },
           "dependencies": {
-            "errno": {
-              "version": "0.1.7",
+            "string-width": {
+              "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "prr": "1.0.1"
-              },
-              "dependencies": {
-                "prr": {
-                  "version": "1.0.1",
-                  "bundled": true
-                }
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -5746,20 +4007,61 @@
             "graceful-fs": "4.1.11",
             "imurmurhash": "0.1.4",
             "signal-exit": "3.0.2"
+          }
+        },
+        "xdg-basedir": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "11.0.0",
+          "bundled": true,
+          "requires": {
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           },
           "dependencies": {
-            "signal-exit": {
-              "version": "3.0.2",
+            "y18n": {
+              "version": "3.2.1",
               "bundled": true
             }
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "bundled": true,
+          "requires": {
+            "camelcase": "4.1.0"
           }
         }
       }
     },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -5769,10 +4071,112 @@
         "ee-first": "1.1.1"
       }
     },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "requires": {
+        "mimic-fn": "1.2.0"
+      }
+    },
+    "opn": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+      "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+      "requires": {
+        "is-wsl": "1.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "1.0.0"
+      }
+    },
+    "os-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
+      "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
+      "requires": {
+        "macos-release": "1.1.0",
+        "win-release": "1.1.1"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "pac-proxy-agent": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-2.0.2.tgz",
+      "integrity": "sha512-cDNAN1Ehjbf5EHkNY5qnRhGPUCp6SnpyVof5fRzN800QV1Y2OkzbH9rmjZkbBRa8igof903yOnjIl6z0SlAhxA==",
+      "requires": {
+        "agent-base": "4.2.1",
+        "debug": "3.1.0",
+        "get-uri": "2.0.2",
+        "http-proxy-agent": "2.1.0",
+        "https-proxy-agent": "2.2.1",
+        "pac-resolver": "3.0.0",
+        "raw-body": "2.3.2",
+        "socks-proxy-agent": "3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "pac-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
+      "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+      "requires": {
+        "co": "4.6.0",
+        "degenerator": "1.0.4",
+        "ip": "1.1.5",
+        "netmask": "1.0.6",
+        "thunkify": "2.1.2"
+      }
+    },
+    "pako": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+    },
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "requires": {
+        "process": "0.11.10",
+        "util": "0.10.4"
+      }
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -5784,12 +4188,40 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
     "prom-client": {
       "version": "10.2.3",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-10.2.3.tgz",
       "integrity": "sha512-Xboq5+TdUwuQtSSDRZRNnb5NprINlgQN999VqUjZxnLKydUNLeIPx6Eiahg6oJua3XBg2TGnh5Cth1s4I6+r7g==",
       "requires": {
         "tdigest": "0.1.1"
+      }
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "2.0.6"
       }
     },
     "proxy-addr": {
@@ -5801,6 +4233,46 @@
         "ipaddr.js": "1.6.0"
       }
     },
+    "proxy-agent": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.3.1.tgz",
+      "integrity": "sha512-CNKuhC1jVtm8KJYFTS2ZRO71VCBx3QSA92So/e6NrY6GoJonkx3Irnk4047EsCcswczwqAekRj3s8qLRGahSKg==",
+      "requires": {
+        "agent-base": "4.2.1",
+        "debug": "3.1.0",
+        "http-proxy-agent": "2.1.0",
+        "https-proxy-agent": "2.2.1",
+        "lru-cache": "4.1.3",
+        "pac-proxy-agent": "2.0.2",
+        "proxy-from-env": "1.0.0",
+        "socks-proxy-agent": "3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "psl": {
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -5810,6 +4282,11 @@
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
     },
     "range-parser": {
       "version": "1.2.0",
@@ -5850,6 +4327,43 @@
         }
       }
     },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "recursive-readdir": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
+      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+      "requires": {
+        "minimatch": "3.0.4"
+      }
+    },
     "redis-commands": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.5.tgz",
@@ -5861,38 +4375,144 @@
       "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
         "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
+        "aws4": "1.8.0",
         "caseless": "0.12.0",
         "combined-stream": "1.0.6",
-        "extend": "3.0.1",
+        "extend": "3.0.2",
         "forever-agent": "0.6.1",
         "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
+        "har-validator": "5.1.0",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
+        "mime-types": "2.1.19",
+        "oauth-sign": "0.9.0",
         "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.4",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "uuid": "3.3.2"
+      },
+      "dependencies": {
+        "aws4": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "har-validator": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+          "requires": {
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
+          }
+        },
+        "mime-db": {
+          "version": "1.35.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+          "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+        },
+        "mime-types": {
+          "version": "2.1.19",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+          "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+          "requires": {
+            "mime-db": "1.35.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "1.1.29",
+            "punycode": "1.4.1"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "requires": {
+        "is-promise": "2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "requires": {
+        "rx-lite": "4.0.8"
       }
     },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "secure-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
+      "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
+    },
+    "semver": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "send": {
       "version": "0.16.2",
@@ -5930,6 +4550,37 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
+    "shallow-clone": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+      "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+      "requires": {
+        "is-extendable": "0.1.1",
+        "kind-of": "2.0.1",
+        "lazy-cache": "0.2.7",
+        "mixin-object": "2.0.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "smart-buffer": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+      "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
+    },
     "snakecase-keys": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-1.1.0.tgz",
@@ -5939,12 +4590,380 @@
         "to-snake-case": "0.1.2"
       }
     },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+    "snyk": {
+      "version": "1.92.7",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.92.7.tgz",
+      "integrity": "sha512-Ij4quN6YoqWc+/d8056Bpv029CnOVI7OnKkXsq3kiSEq36C33Dwyq+lQFNIaJUy1nup6KFdTTRqgmvG2hbLUBA==",
       "requires": {
-        "hoek": "4.2.1"
+        "abbrev": "1.1.1",
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "configstore": "3.1.2",
+        "debug": "3.1.0",
+        "hasbin": "1.2.3",
+        "inquirer": "3.3.0",
+        "lodash": "4.17.10",
+        "needle": "2.2.2",
+        "opn": "5.3.0",
+        "os-name": "2.0.1",
+        "proxy-agent": "2.3.1",
+        "proxy-from-env": "1.0.0",
+        "recursive-readdir": "2.2.2",
+        "semver": "5.5.1",
+        "snyk-config": "2.2.0",
+        "snyk-docker-plugin": "1.10.4",
+        "snyk-go-plugin": "1.5.2",
+        "snyk-gradle-plugin": "1.3.0",
+        "snyk-module": "1.8.2",
+        "snyk-mvn-plugin": "1.2.0",
+        "snyk-nodejs-lockfile-parser": "1.4.1",
+        "snyk-nuget-plugin": "1.6.5",
+        "snyk-php-plugin": "1.5.1",
+        "snyk-policy": "1.12.0",
+        "snyk-python-plugin": "1.8.1",
+        "snyk-resolve": "1.0.1",
+        "snyk-resolve-deps": "3.1.0",
+        "snyk-sbt-plugin": "1.3.1",
+        "snyk-tree": "1.0.0",
+        "snyk-try-require": "1.3.1",
+        "tempfile": "2.0.0",
+        "then-fs": "2.0.0",
+        "undefsafe": "2.0.2",
+        "uuid": "3.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "snyk-config": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/snyk-config/-/snyk-config-2.2.0.tgz",
+      "integrity": "sha512-mq0wbP/AgjcmRq5i5jg2akVVV3iSYUPTowZwKn7DChRLDL8ySOzWAwan+ImXiyNbrWo87FNI/15O6MpOnTxOIg==",
+      "requires": {
+        "debug": "3.1.0",
+        "lodash": "4.17.10",
+        "nconf": "0.10.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "snyk-docker-plugin": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.10.4.tgz",
+      "integrity": "sha512-79yWMaISNbtfTY9UtTF7K24cE4k1tRsxDOZo4/a8WlyO/dmmvbdcyz3jtHiFnS8NZqOkXf7ngqae1hmcR7CdPA==",
+      "requires": {
+        "debug": "3.1.0",
+        "fs-extra": "5.0.0",
+        "needle": "2.2.2",
+        "temp-dir": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "snyk-go-plugin": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.5.2.tgz",
+      "integrity": "sha512-XWajcSh6Ld+I+WdcyU3DGDuE2ydThQd8ORkESy0nQ2LwekygLYVYN66OBy0uxpqYfd4qoqeg+J8lb4oGzCmyGA==",
+      "requires": {
+        "graphlib": "2.1.5",
+        "tmp": "0.0.33",
+        "toml": "2.3.3"
+      }
+    },
+    "snyk-gradle-plugin": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-1.3.0.tgz",
+      "integrity": "sha512-rKZcPwbDM9zk3pFcO0w77MIKOZTkk5ZBVBkBlTlUiFg+eNOKqPTmw2hBGF5NB4ASQmMnx3uB1C8+hrQ405CthA==",
+      "requires": {
+        "clone-deep": "0.3.0"
+      }
+    },
+    "snyk-module": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/snyk-module/-/snyk-module-1.8.2.tgz",
+      "integrity": "sha512-XqhdbZ/CUuJ5gSaYdYfapLqx9qm2Mp6nyRMBCLXe9tJSiohOJsc9fQuUDbdOiRCqpA4BD6WLl+qlwOJmJoszBg==",
+      "requires": {
+        "debug": "3.1.0",
+        "hosted-git-info": "2.7.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "snyk-mvn-plugin": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-1.2.0.tgz",
+      "integrity": "sha512-ieTWhn1MB88gEQ6nUtGCeUKQ6Xoxm+u+QmD9u3zfP1QS5ep9fWt3YYDUQjgUiDTJJy7QyVQdZ/fsz3RECnOA7w=="
+    },
+    "snyk-nodejs-lockfile-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.4.1.tgz",
+      "integrity": "sha512-xjkf1BHk7HQlp4ABIWPtEvAOAvWhwMtJ7ElQVUvKBHPVHjMEz3mucBRfrtpuyDBJ3DaBlN8Wiw+kcEinX6f09w==",
+      "requires": {
+        "lodash": "4.17.10",
+        "path": "0.12.7",
+        "source-map-support": "0.5.9"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "snyk-nuget-plugin": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.6.5.tgz",
+      "integrity": "sha512-3qIndzkxCxiaGvAwMkqChbChGdwhNePPyfi0WjhC/nJGwecqU3Fb/NeTW7lgyT+xoq/dFnzW0DgBJ4+AyNA2gA==",
+      "requires": {
+        "debug": "3.1.0",
+        "jszip": "3.1.5",
+        "lodash": "4.17.10",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "snyk-php-plugin": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.5.1.tgz",
+      "integrity": "sha512-g5QSHBsRJ2O4cNxKC4zlWwnQYiSgQ77Y6QgGmo3ihPX3VLZrc1amaZIpPsNe1jwXirnGj2rvR5Xw+jDjbzvHFw==",
+      "requires": {
+        "debug": "3.1.0",
+        "lodash": "4.17.10",
+        "path": "0.12.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "snyk-policy": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.12.0.tgz",
+      "integrity": "sha512-CEioNnDzccHyid7UIVl3bJ1dnG4co4ofI+KxuC1mo0IUXy64gxnBTeVoZF5gVLWbAyxGxSeW8f0+8GmWMHVb7w==",
+      "requires": {
+        "debug": "3.1.0",
+        "email-validator": "2.0.4",
+        "js-yaml": "3.12.0",
+        "lodash.clonedeep": "4.5.0",
+        "semver": "5.5.1",
+        "snyk-module": "1.8.2",
+        "snyk-resolve": "1.0.1",
+        "snyk-try-require": "1.3.1",
+        "then-fs": "2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "snyk-python-plugin": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.8.1.tgz",
+      "integrity": "sha512-DsUBkQZiPlXGkwzhxxEo2Tvfq6XhygWQThWM0yRBythi9M5n8UimZEwdkBHPj7xKC1clsB8boM3+sT/E1x6XGA==",
+      "requires": {
+        "tmp": "0.0.33"
+      }
+    },
+    "snyk-resolve": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/snyk-resolve/-/snyk-resolve-1.0.1.tgz",
+      "integrity": "sha512-7+i+LLhtBo1Pkth01xv+RYJU8a67zmJ8WFFPvSxyCjdlKIcsps4hPQFebhz+0gC5rMemlaeIV6cqwqUf9PEDpw==",
+      "requires": {
+        "debug": "3.1.0",
+        "then-fs": "2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "snyk-resolve-deps": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/snyk-resolve-deps/-/snyk-resolve-deps-3.1.0.tgz",
+      "integrity": "sha512-YVAelR+dTpqLgfk6lf6WgOlw+MGmGI0r3/Dny8tUbJJ9uVTHTRAOdZCbUyTFqJG7oEmEZxUwmfjqgAuniYwx8Q==",
+      "requires": {
+        "ansicolors": "0.3.2",
+        "debug": "3.1.0",
+        "lodash.assign": "4.2.0",
+        "lodash.assignin": "4.2.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.get": "4.4.2",
+        "lodash.set": "4.3.2",
+        "lru-cache": "4.1.3",
+        "semver": "5.5.1",
+        "snyk-module": "1.8.2",
+        "snyk-resolve": "1.0.1",
+        "snyk-tree": "1.0.0",
+        "snyk-try-require": "1.3.1",
+        "then-fs": "2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "snyk-sbt-plugin": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-1.3.1.tgz",
+      "integrity": "sha512-un9ddM4M+7Ye/zhkh5Cm6EYMXU0Z/aM8wuYZvu4O+wd8sonoUClwckzJlsaI2BA7xvfDL9qQUaImtpgy94v5JQ==",
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "snyk-tree": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/snyk-tree/-/snyk-tree-1.0.0.tgz",
+      "integrity": "sha1-D7cxdtvzLngvGRAClBYESPkRHMg=",
+      "requires": {
+        "archy": "1.0.0"
+      }
+    },
+    "snyk-try-require": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/snyk-try-require/-/snyk-try-require-1.3.1.tgz",
+      "integrity": "sha1-bgJvkuZK9/zM6h7lPVJIQeQYohI=",
+      "requires": {
+        "debug": "3.1.0",
+        "lodash.clonedeep": "4.5.0",
+        "lru-cache": "4.1.3",
+        "then-fs": "2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "socks": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+      "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
+      "requires": {
+        "ip": "1.1.5",
+        "smart-buffer": "1.1.15"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
+      "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
+      "requires": {
+        "agent-base": "4.2.1",
+        "socks": "1.1.10"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-support": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+      "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+      "requires": {
+        "buffer-from": "1.1.1",
+        "source-map": "0.6.1"
       }
     },
     "spected": {
@@ -5961,6 +4980,11 @@
           "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc="
         }
       }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.14.1",
@@ -5982,10 +5006,35 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "requires": {
+        "ansi-regex": "3.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "3.0.0"
+      }
     },
     "tdigest": {
       "version": "0.1.1",
@@ -5993,6 +5042,46 @@
       "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
       "requires": {
         "bintrees": "1.0.1"
+      }
+    },
+    "temp-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
+    },
+    "tempfile": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
+      "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
+      "requires": {
+        "temp-dir": "1.0.0",
+        "uuid": "3.2.1"
+      }
+    },
+    "then-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
+      "integrity": "sha1-cveS3Z0xcFqRrhnr/Piz+WjIHaI=",
+      "requires": {
+        "promise": "7.3.1"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "thunkify": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
+      "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-no-case": {
@@ -6016,13 +5105,10 @@
         "to-no-case": "0.1.1"
       }
     },
-    "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-      "requires": {
-        "punycode": "1.4.1"
-      }
+    "toml": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
+      "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -6038,6 +5124,14 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
     "type-is": {
       "version": "1.6.16",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
@@ -6047,10 +5141,44 @@
         "mime-types": "2.1.18"
       }
     },
+    "undefsafe": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.2.tgz",
+      "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
+      "requires": {
+        "debug": "2.6.9"
+      }
+    },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "requires": {
+        "crypto-random-string": "1.0.0"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -6075,6 +5203,157 @@
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
+      }
+    },
+    "win-release": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+      "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+      "requires": {
+        "semver": "5.5.1"
+      }
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
+      }
+    },
+    "write-file-atomic": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    },
+    "xregexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yargs": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "requires": {
+        "camelcase": "2.1.1",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "os-locale": "1.4.0",
+        "string-width": "1.0.2",
+        "window-size": "0.1.4",
+        "y18n": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "express-physical": "^0.4.0",
     "ioredis": "^3.2.2",
     "ip": "^1.1.5",
-    "npm": "^6.0.0",
+    "npm": "^6.4.0",
     "prom-client": "^10.2.3",
-    "request": "^2.85.0",
-    "snyk": "^1.88.0"
+    "request": "^2.88.0",
+    "snyk": "^1.92.7"
   },
   "snyk": true
 }


### PR DESCRIPTION
There is a vulnerability in the transitive dependency `lodash`. This patch ensures that it is bumped to a version where the vulnerability is fixed.